### PR TITLE
Kill child processes on dead parent

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import os
 import yaml
 import time
+import socket
 import logging
 from multiprocessing import Process, Pipe
 
@@ -171,6 +172,8 @@ class NapalmLogs:
         open the socket to start receiving messages.
         '''
         # TODO prepare the binding to be able to listen to syslog messages
+        skt = None
+        # TODO
         log.info('Preparing the transport')
         self.transport.start()
         log.info('Starting child processes for each device type')
@@ -211,8 +214,7 @@ class NapalmLogs:
             )
         )
         log.debug('Starting the listener process')
-        listener = NapalmLogsListenerProc(self.hostname,
-                                          self.port,
+        listener = NapalmLogsListenerProc(skt,  # Socket object
                                           listen_pipe)
         self.plisten = Process(target=listener.start)
         self.plisten.start()

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -32,7 +32,9 @@ class NapalmLogs:
                  config_path=None,
                  config_dict=None,
                  extension_config_path=None,
-                 extension_config_dict=None):
+                 extension_config_dict=None,
+                 log_level='warning',
+                 log_fmt='%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'):
         '''
         Init the napalm-logs engine.
 
@@ -48,14 +50,14 @@ class NapalmLogs:
         self.publish_port = publish_port
         self.config_path = config_path
         self.config_dict = config_dict
+        self._transport_type = transport
         self.extension_config_path = extension_config_path
         self.extension_config_dict = extension_config_dict
-        # Setup logging
-        self.log = log  # TODO: proper log setup
-        #
-        transport_class = get_transport(transport)
-        self.transport = transport_class(self.publish_hostname,
-                                         self.publish_port)
+        self.log_level = log_level
+        self.log_fmt = log_fmt
+        # Setup the environment
+        self._setup_log()
+        self._setup_transport()
         self._build_config()
         self._precompile_regex()
         # Private vars
@@ -64,10 +66,33 @@ class NapalmLogs:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.stop_engine()
         if exc_type is not None:
+            log.error('Exiting due to unhandled exception', exc_info=True)
             self.__raise_clean_exception(exc_type, exc_value, exc_traceback)
 
     def __del__(self):
         self.stop_engine()
+
+    def _setup_log(self):
+        '''
+        Setup the log object.
+        '''
+        logging_level = {
+            'debug': logging.DEBUG,
+            'info': logging.INFO,
+            'warning': logging.WARNING,
+            'error': logging.ERROR,
+            'critical': logging.CRITICAL
+        }.get(self.log_level.lower())
+        logging.basicConfig(format=self.log_fmt,
+                            level=logging_level)
+
+    def _setup_transport(self):
+        '''
+        Setup the transport.
+        '''
+        transport_class = get_transport(self._transport_type)
+        self.transport = transport_class(self.publish_hostname,
+                                         self.publish_port)
 
     def _load_config(self, path):
         '''
@@ -80,7 +105,7 @@ class NapalmLogs:
                 'Unable to read from {path}: '
                 'the directory does not exist!'
             ).format(path=path)
-            self.log.error(msg)
+            log.error(msg)
             raise IOError(msg)
         files = os.listdir(path)
         # Read all files under the config dir
@@ -95,12 +120,11 @@ class NapalmLogs:
                 with open(filepath, 'r') as fstream:
                     config[filename] = yaml.load(fstream)
             except yaml.YAMLError as yamlexc:
-                self.log.error('Invalid YAML file: {}'.format(filepath))
-                self.log.error(yamlexc)
+                log.error('Invalid YAML file: {}'.format(filepath), exc_info=True)
                 raise IOError(yamlexc)
         if not config:
             msg = 'Unable to find proper configuration files under {path}'.format(path=path)
-            self.log.error(msg)
+            log.error(msg)
             raise IOError(msg)
         return config
 
@@ -116,12 +140,12 @@ class NapalmLogs:
                     os.path.dirname(os.path.realpath(__file__)),
                     'config'
                 )
-            self.log.info('Reading the configuration from {path}'.format(path=self.config_path))
+            log.info('Reading the configuration from {path}'.format(path=self.config_path))
             self.config_dict = self._load_config(self.config_path)
         if not self.extension_config_dict and self.extension_config_path:
             # When extension config is not sent as dict
             # But `extension_config_path` is specified
-            self.log.info('Reading extension configuration from {path}'.format(path=self.extension_config_path))
+            log.info('Reading extension configuration from {path}'.format(path=self.extension_config_path))
             self.extension_config_dict = self._load_config(self.extension_config_path)
         elif not self.extension_config_dict:
             self.extension_config_dict = {}
@@ -147,60 +171,58 @@ class NapalmLogs:
         open the socket to start receiving messages.
         '''
         # TODO prepare the binding to be able to listen to syslog messages
-        self.log.info('Preparing the transport')
+        log.info('Preparing the transport')
         self.transport.start()
-        self.log.info('Starting child processes for each device type')
+        log.info('Starting child processes for each device type')
         os_pipe_map = {}
         for device_os, device_config in self.config_dict.items():
             parent_pipe, child_pipe = Pipe()
-            self.log.debug('Initialized pipe for {dos}'.format(dos=device_os))
-            self.log.debug('Parent handle is {phandle} ({phash})'.format(phandle=str(parent_pipe),
+            log.debug('Initialized pipe for {dos}'.format(dos=device_os))
+            log.debug('Parent handle is {phandle} ({phash})'.format(phandle=str(parent_pipe),
                                                                     phash=hash(parent_pipe)))
-            self.log.debug('Child handle is {chandle} ({chash})'.format(chandle=str(child_pipe),
+            log.debug('Child handle is {chandle} ({chash})'.format(chandle=str(child_pipe),
                                                                     chash=hash(child_pipe)))
-            self.log.info('Starting the child process for {dos}'.format(dos=device_os))
+            log.info('Starting the child process for {dos}'.format(dos=device_os))
             dos = NapalmLogsDeviceProc(device_os,
                                        device_config,
                                        self.transport,
-                                       child_pipe,
-                                       self.log)
+                                       child_pipe)
             os_pipe_map[device_os] = parent_pipe
             os_proc = Process(target=dos.start)
             os_proc.start()
-            self.log.debug('Started process {pname} for {dos}, having PID {pid}'.format(
+            log.debug('Started process {pname} for {dos}, having PID {pid}'.format(
                     pname=os_proc._name,
                     dos=device_os,
                     pid=os_proc.pid
                 )
             )
             self.__os_proc_map[device_os] = os_proc
-        self.log.info('Start listening to syslog messages')
+        log.debug('Setting up the syslog pipe')
         listen_pipe, serve_pipe = Pipe()
+        log.debug('Starting the server process')
         server = NapalmLogsServerProc(serve_pipe,
                                       os_pipe_map,
-                                      self.config_dict,
-                                      self.log)
+                                      self.config_dict)
         pserve = Process(target=server.start)
         pserve.start()
-        self.log.debug('Started server process as {pname} with PID {pid}'.format(
+        log.debug('Started server process as {pname} with PID {pid}'.format(
                 pname=pserve._name,
                 pid=pserve.pid
             )
         )
+        log.debug('Starting the listener process')
         listener = NapalmLogsListenerProc(self.hostname,
                                           self.port,
-                                          listen_pipe,
-                                          self.log)
+                                          listen_pipe)
         plisten = Process(target=listener.start)
         plisten.start()
-        self.log.debug('Started listener process as {pname} with PID {pid}'.format(
+        log.debug('Started listener process as {pname} with PID {pid}'.format(
                 pname=plisten._name,
                 pid=pserve.pid
             )
         )
-        pserve.join()
-        plisten.join()
 
     def stop_engine(self):
-        self.log.info('Shutting down the engine')
-        self.transport.tear_down()
+        log.info('Shutting down the engine')
+        if hasattr(self, 'transport'):
+            self.transport.tear_down()

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+'''
+napalm-logs device worker process
+'''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+# Import python stdlib
+import os
+import threading
+
+# Import napalm-logs pkgs
+from napalm_logs.proc import NapalmLogsProc
+
+
+class NapalmLogsDeviceProc(NapalmLogsProc):
+    def __init__(self,
+                 name,
+                 config,
+                 transport,
+                 pipe,
+                 log):
+        self._name = name
+        self._config = config
+        self._transport = transport
+        self._pipe = pipe
+        self._log = log
+        self.__running = False
+
+    def __del__(self):
+        self.stop()
+        # Make sure to close the pipe
+        self._pipe.close()
+        delattr(self, '_pipe')
+
+    def _parse(self, msg):
+        '''
+        Parse a syslog message and check what OpenConfig object should
+        be generated.
+        '''
+        pass
+
+    def _emit(self, **kwargs):
+        '''
+        Emit an OpenConfig object given a certain combination of
+        fields mappeed in the config to the corresponding hierarchy.
+        '''
+        pass
+
+    def _publish(self, obj):
+        '''
+        Publish the OC object.
+        '''
+        self._transport.publish(obj)
+
+    def start(self):
+        '''
+        Start the worker process.
+        '''
+        # Start suicide polling thread
+        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
+        thread.start()
+        self.__running = True
+        while self.__running:
+            msg = self._pipe.recv()
+            # # Will wait till a message is available
+            # kwargs = self._parse(self, msg)
+            # oc_obj = self._emit(self, **kwargs)
+            # self._publish(oc_obj)
+
+    def stop(self):
+        '''
+        Stop the worker process.
+        '''
+        self.__running = False

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-napalm-logs device worker process
+Device worker process
 '''
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import python stdlib
 import os
-import threading
 import logging
+import threading
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 
 
 class NapalmLogsDeviceProc(NapalmLogsProc):
+    '''
+    Device sub-process class.
+    '''
     def __init__(self,
                  name,
                  config,
@@ -26,7 +29,7 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         self._config = config
         self._transport = transport
         self._pipe = pipe
-        self.__running = False
+        self.__up = False
 
     def __del__(self):
         self.stop()
@@ -61,8 +64,8 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         # Start suicide polling thread
         thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
         thread.start()
-        self.__running = True
-        while self.__running:
+        self.__up = True
+        while self.__up:
             msg = self._pipe.recv()
             # # Will wait till a message is available
             # kwargs = self._parse(self, msg)
@@ -73,4 +76,4 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         '''
         Stop the worker process.
         '''
-        self.__running = False
+        self.__up = False

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -8,9 +8,12 @@ from __future__ import unicode_literals
 # Import python stdlib
 import os
 import threading
+import logging
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
+
+log = logging.getLogger(__name__)
 
 
 class NapalmLogsDeviceProc(NapalmLogsProc):
@@ -18,13 +21,11 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                  name,
                  config,
                  transport,
-                 pipe,
-                 log):
+                 pipe):
         self._name = name
         self._config = config
         self._transport = transport
         self._pipe = pipe
-        self._log = log
         self.__running = False
 
     def __del__(self):

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+'''
+napalm-logs listener worker process
+'''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+# Import pythond std
+import os
+import threading
+
+# Import napalm-logs pkgs
+from napalm_logs.proc import NapalmLogsProc
+
+
+class NapalmLogsListenerProc(NapalmLogsProc):
+    def __init__(self,
+                 hostname,
+                 port,
+                 pipe,
+                 log):
+        self.hostname = hostname
+        self.port = port
+        self.__pipe = pipe
+        self.__up = False
+
+    def start(self):
+        '''
+        Listen to messages and queue them.
+        '''
+        # Start suicide polling thread
+        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
+        thread.start()
+        self.__up = True
+        while self.__up:
+            # TODO listen to messages on the syslog socket
+            msg = 'crap'
+            self.__pipe.send(msg)
+            # TODO only take the message and queue it directly

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -8,17 +8,19 @@ from __future__ import unicode_literals
 # Import pythond stdlib
 import os
 import threading
+import logging
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
+
+log = logging.getLogger(__name__)
 
 
 class NapalmLogsListenerProc(NapalmLogsProc):
     def __init__(self,
                  hostname,
                  port,
-                 pipe,
-                 log):
+                 pipe):
         self.hostname = hostname
         self.port = port
         self.__pipe = pipe

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-napalm-logs listener worker process
+Listener worker process
 '''
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import pythond stdlib
 import os
-import threading
 import logging
+import threading
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 
 
 class NapalmLogsListenerProc(NapalmLogsProc):
+    '''
+    Listener sub-process class.
+    '''
     def __init__(self,
                  hostname,
                  port,
@@ -39,3 +42,6 @@ class NapalmLogsListenerProc(NapalmLogsProc):
             msg = 'crap'
             self.__pipe.send(msg)
             # TODO only take the message and queue it directly
+
+    def stop(self):
+        self.__up = False

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -21,11 +21,9 @@ class NapalmLogsListenerProc(NapalmLogsProc):
     Listener sub-process class.
     '''
     def __init__(self,
-                 hostname,
-                 port,
+                 socket,
                  pipe):
-        self.hostname = hostname
-        self.port = port
+        self.socket = socket
         self.__pipe = pipe
         self.__up = False
 

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -5,7 +5,7 @@ napalm-logs listener worker process
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-# Import pythond std
+# Import pythond stdlib
 import os
 import threading
 

--- a/napalm_logs/proc.py
+++ b/napalm_logs/proc.py
@@ -8,6 +8,9 @@ from __future__ import unicode_literals
 # Import pythond stdlib
 import os
 import time
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class NapalmLogsProc:
@@ -23,4 +26,5 @@ class NapalmLogsProc:
             except OSError:
                 # Forcibly exit
                 # Regular sys.exit raises an exception
+                log.warning('The parent is not alive, exiting.')
                 os._exit(999)

--- a/napalm_logs/proc.py
+++ b/napalm_logs/proc.py
@@ -5,7 +5,7 @@ napalm-logs base worker process
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-# Import pythond std
+# Import pythond stdlib
 import os
 import time
 

--- a/napalm_logs/proc.py
+++ b/napalm_logs/proc.py
@@ -5,60 +5,22 @@ napalm-logs base worker process
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-# Import python stdlib
-from queue import Queue
+# Import pythond std
+import os
+import time
 
 
 class NapalmLogsProc:
-    def __init__(self,
-                 name,
-                 config,
-                 transport,
-                 log=None):
-        self._name = name
-        self._config = config
-        self._transport = transport
-        self._log = log
-        self.__running = False
-
-    def _parse(self, msg):
+    def _suicide_when_without_parent(self, parent_pid):
         '''
-        Parse a syslog message and check what OpenConfig object should
-        be generated.
+        Kill this process when the parent died.
         '''
-        pass
-
-    def _emit(self, **kwargs):
-        '''
-        Emit an OpenConfig object given a certain combination of
-        fields mappeed in the config to the corresponding hierarchy.
-        '''
-        pass
-
-    def _publish(self, obj):
-        '''
-        Publish the OC object.
-        '''
-        self._transport.publish(obj)
-
-    def start(self, q):
-        '''
-        Start the worker process.
-        '''
-        self._q = q
-        self.__running = True
-        try:
-            while self.__running:
-                msg = self._q.get(block=True)
-                # # Will wait till a message is available
-                # kwargs = self._parse(self, msg)
-                # oc_obj = self._emit(self, **kwargs)
-                # self._publish(oc_obj)
-        except KeyboardInterrupt:
-            self.stop()
-
-    def stop(self):
-        '''
-        Stop the worker process.
-        '''
-        self.__running = False
+        while True:
+            time.sleep(5)
+            try:
+                # Check pid alive
+                os.kill(parent_pid, 0)
+            except OSError:
+                # Forcibly exit
+                # Regular sys.exit raises an exception
+                os._exit(999)

--- a/napalm_logs/proc.py
+++ b/napalm_logs/proc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-napalm-logs base worker process
+Base worker process
 '''
 from __future__ import absolute_import
 from __future__ import unicode_literals
@@ -14,6 +14,9 @@ log = logging.getLogger(__name__)
 
 
 class NapalmLogsProc:
+    '''
+    Sub-process base class.
+    '''
     def _suicide_when_without_parent(self, parent_pid):
         '''
         Kill this process when the parent died.

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+'''
+napalm-logs server worker process
+'''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+# Import pythond std
+import os
+import threading
+
+# Import napalm-logs pkgs
+from napalm_logs.proc import NapalmLogsProc
+
+
+class NapalmLogsServerProc(NapalmLogsProc):
+    def __init__(self,
+                 pipe,
+                 os_pipe_map,
+                 config,
+                 log):
+        self.config = config
+        self.log = log
+        self.__pipe = pipe
+        self.__os_pipe_map = os_pipe_map
+        self.__up = False
+
+    def _identify_os(self, msg):
+        '''
+        Using the prefix of the syslog message,
+        we are able to identify the operating system and then continue parsing.
+        '''
+        return ()
+
+    def start(self):
+        '''
+        Take the messages from the queue,
+        inspect and identify the operating system,
+        then queue the message correspondingly.
+        '''
+        # Start suicide polling thread
+        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
+        thread.start()
+        self.__up = True
+        while self.__up:
+            # Take messages from the main queue
+            msg = self.__pipe.recv()
+            id_os = self._identify_os(msg)
+            if not id_os or not isinstance(id_os, tuple):
+                # _identify_os shoudl return a non-empty tuple
+                # providing the info for the device OS
+                # and the core message
+                continue
+            dev_os, core_msg = id_os
+            # Then send the message in the right queue
+            self.__os_pipe_map[dev_os].send(core_msg)

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 '''
-napalm-logs server worker process
+Server worker process
 '''
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import pythond stdlib
 import os
-import threading
 import logging
+import threading
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
@@ -17,6 +17,9 @@ log = logging.getLogger(__name__)
 
 
 class NapalmLogsServerProc(NapalmLogsProc):
+    '''
+    Server sub-process class.
+    '''
     def __init__(self,
                  pipe,
                  os_pipe_map,
@@ -55,3 +58,6 @@ class NapalmLogsServerProc(NapalmLogsProc):
             dev_os, core_msg = id_os
             # Then send the message in the right queue
             self.__os_pipe_map[dev_os].send(core_msg)
+
+    def stop(self):
+        self.__up = False

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -5,7 +5,7 @@ napalm-logs server worker process
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-# Import pythond std
+# Import pythond stdlib
 import os
 import threading
 

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -8,19 +8,20 @@ from __future__ import unicode_literals
 # Import pythond stdlib
 import os
 import threading
+import logging
 
 # Import napalm-logs pkgs
 from napalm_logs.proc import NapalmLogsProc
+
+log = logging.getLogger(__name__)
 
 
 class NapalmLogsServerProc(NapalmLogsProc):
     def __init__(self,
                  pipe,
                  os_pipe_map,
-                 config,
-                 log):
+                 config):
         self.config = config
-        self.log = log
         self.__pipe = pipe
         self.__os_pipe_map = os_pipe_map
         self.__up = False
@@ -30,7 +31,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
         Using the prefix of the syslog message,
         we are able to identify the operating system and then continue parsing.
         '''
-        return ()
+        return ('junos', 'crap')
 
     def start(self):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyzmq
+pyyaml
 napalm-yang
 


### PR DESCRIPTION
Make sure to clear all the processes when the parent process
is dead. Doing so, we need to move the server and the listener in
a separate process, running their onw instance.
Also, replace the Queue with the Pipe as there's one consumer only
for each.