### PR TITLE
Verify config and compile messages regex

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 # Import std lib
 import os
+import re
 import time
 import yaml
 import socket
@@ -14,14 +15,31 @@ import logging
 from multiprocessing import Process, Pipe
 
 # Import napalm-logs pkgs
-import napalm_logs.exceptions
 from napalm_logs.transport import get_transport
 from napalm_logs.device import NapalmLogsDeviceProc
 from napalm_logs.server import NapalmLogsServerProc
 from napalm_logs.listener import NapalmLogsListenerProc
 from napalm_logs.exceptions import UnableToBindException
+from napalm_logs.exceptions import MissConfigurationException
 
 log = logging.getLogger(__name__)
+
+VALID_CONFIG = {
+    'prefix': {
+        'values': {
+            'error': basestring
+            },
+        'line': basestring
+        },
+    'messages': {
+        '*': {
+            'values': dict,
+            'line': basestring,
+            'model': basestring,
+            'mapping': dict
+            }
+        }
+    }
 
 
 class NapalmLogs:
@@ -61,6 +79,7 @@ class NapalmLogs:
         self._setup_log()
         self._setup_transport()
         self._build_config()
+        self._verify_config()
         self._precompile_regex()
         # Private vars
         self.__os_proc_map = {}
@@ -129,6 +148,61 @@ class NapalmLogs:
             log.error(msg)
             raise IOError(msg)
         return config
+
+    @staticmethod
+    def _raise_config_exception(error_string):
+        log.error(error_string, exc_info=True)
+        raise MissConfigurationException(error_string)
+
+    def _verify_config_key(self, key, value, valid, config, dev_os, key_path):
+        key_path.append(key)
+        if not config.get(key):
+            self._raise_config_exception('Unable to find key "{}" for {}'.format(':'.join(key_path), dev_os))
+        if isinstance(value, type):
+            if not isinstance(config[key], value):
+                self._raise_config_exception('Key "{}" for {} should be {}'.format(':'.join(key_path), dev_os, value))
+        elif isinstance(value, dict):
+            if not isinstance(config[key], dict):
+                self._raise_config_exception('Key "{}" for {} should be of type <dict>'.format(':'.join(key_path), dev_os))
+            self._verify_config_dict(value, config[key], dev_os, key_path)
+            # As we have already checked that the config below this point is correct, we know that "line" and "values"
+            # exists in the config if they are present in the valid config
+            if 'line' in value.keys() and 'values' in value.keys():
+                from_line = re.findall('\{(\w+)\}', config[key]['line'])
+                if set(from_line) != set(config[key]['values']):
+                    self._raise_config_exception('The "values" do not match variables in "line" for {} in {}'.format(':'.join(key_path), dev_os))
+        key_path.remove(key)
+
+    def _verify_config_dict(self, valid, config, dev_os, key_path=None):
+        if not key_path:
+            key_path = []
+        for key, value in valid.items():
+            # If the key is '*' then we should check all keys in the config to make sure they match the allowed values
+            if key == '*':
+                for config_key in config.keys():
+                    self._verify_config_key(config_key, value, valid, config, dev_os, key_path)
+            else:
+                self._verify_config_key(key, value, valid, config, dev_os, key_path)
+
+    def _verify_config(self):
+        '''
+        Verify that the config is correct
+        '''
+        if not self.config_dict:
+            self._raise_config_exception('No config found')
+
+
+        # Check for device conifg, if there isn't anything then just log, do not raise an exception
+        for dev_os, dev_config in self.config_dict.items():
+            if not dev_config:
+                log.error('No config found for {}'.format(dev_os))
+                continue
+
+            # Compare the valid opts with the conifg
+            self._verify_config_dict(VALID_CONFIG, dev_config, dev_os)
+
+        log.debug('Read the config without error \o/')
+
 
     def _build_config(self):
         '''

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -7,7 +7,7 @@ prefix:
     processName: (\w+)
     processId: (\d+)
     error: (\w+)
-  line: '{date} {time}  {host} {processName}[{processId}]: {error}: '
+  line: '{date} {time}  {host} {processName}[{processId}]:  {error}:'
 
 messages:
   BGP_PREFIX_THRESH_EXCEEDED:

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 # Import python stdlib
 import os
+import re
 import logging
 import threading
 
@@ -30,6 +31,8 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         self._transport = transport
         self._pipe = pipe
         self.__up = False
+        self.compiled_messages = None
+        self._compile_messages()
 
     def __del__(self):
         self.stop()
@@ -37,12 +40,59 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         self._pipe.close()
         delattr(self, '_pipe')
 
-    def _parse(self, msg):
+    def _compile_messages(self):
+        '''
+        Create a dict of all OS messages and their compiled regexs
+        '''
+        self.compiled_messages = {}
+        if not self._config:
+            return
+        for message_name, data in self._config.get('messages', {}).items():
+            values = data.get('values', {})
+            line = data.get('line', '')
+
+            # We will now figure out which position each value is in so we can use it with the match statement
+            position = {}
+            for key in values.keys():
+                position[line.find('{' + key + '}')] = key
+            sorted_position = {}
+            for i, elem in enumerate(sorted(position.items())):
+                sorted_position[elem[1]] = i + 1
+
+            # Escape the line, then remove the escape for the curly bracets so they can be used when formatting
+            escaped = re.escape(line).replace('\{', '{').replace('\}', '}')
+
+            self.compiled_messages[message_name] = {
+                'line': re.compile(escaped.format(**values)),
+                'positions': sorted_position,
+                'values': values
+                }
+
+    def _parse(self, msg_dict):
         '''
         Parse a syslog message and check what OpenConfig object should
         be generated.
         '''
-        pass
+        regex_data = self.compiled_messages.get(msg_dict['error'])
+        if not regex_data:
+            log.debug('Unable to find entry for os: {} error {}'.format(self._name, msg_dict.get('error', '')))
+            return
+        match = regex_data.get('line', '').search(msg_dict['message'])
+        if not match:
+            log.debug(
+                'Configured regex did not match for os: {} error {}'.format(
+                    self._name,
+                    msg_dict.get('error', '')
+                    )
+                )
+            return
+        positions = regex_data.get('positions', {})
+        values = regex_data.get('values')
+        ret = {}
+        for key in values.keys():
+            ret[key] = match.group(positions.get(key))
+        return ret
+
 
     def _emit(self, **kwargs):
         '''
@@ -66,11 +116,12 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         thread.start()
         self.__up = True
         while self.__up:
-            msg = self._pipe.recv()
+            msg_dict, address = self._pipe.recv()
             # # Will wait till a message is available
-            # kwargs = self._parse(self, msg)
             # oc_obj = self._emit(self, **kwargs)
             # self._publish(oc_obj)
+            kwargs = self._parse(msg_dict)
+
 
     def stop(self):
         '''

--- a/napalm_logs/exceptions.py
+++ b/napalm_logs/exceptions.py
@@ -18,3 +18,9 @@ class UnableToBindException(NapalmLogsException):
     When the provided IP string is neither a valid IPv4 address or a valid IPv6 address
     '''
     pass
+
+class MissConfigurationException(NapalmLogsException):
+    '''
+    When the provided IP string is neither a valid IPv4 address or a valid IPv6 address
+    '''
+    pass

--- a/napalm_logs/listener.py
+++ b/napalm_logs/listener.py
@@ -15,6 +15,8 @@ from napalm_logs.proc import NapalmLogsProc
 
 log = logging.getLogger(__name__)
 
+BUFFER_SIZE = 1024
+
 
 class NapalmLogsListenerProc(NapalmLogsProc):
     '''
@@ -36,10 +38,9 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         thread.start()
         self.__up = True
         while self.__up:
-            # TODO listen to messages on the syslog socket
-            msg, _ = self.socket.recvfrom(1024) # TODO set the buffer size elsewhere
-            self.__pipe.send(msg)
-            # TODO only take the message and queue it directly
+            msg, addr = self.socket.recvfrom(BUFFER_SIZE)
+            # Addr contains (IP, port), we only care about the IP
+            self.__pipe.send((msg, addr[0]))
 
     def stop(self):
         self.__up = False


### PR DESCRIPTION
Add a check to verify the config. At the moment we are only using dicts
and strings in the config, so only added checks for those. If in future
we add any lists then we will need to update the config checker.

Complile the regex for each OS and store the dict ready to be checked
against. We will check the error title and if it matches then we will
use the regex, this should cut down on regex checks required.