### PR TITLE
Change config to have errors stored in a list

### DIFF
--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -34,16 +34,20 @@ DEFAULT_DELIM = '/'
 VALID_CONFIG = {
     'prefix': {
         'values': {
-            'error': basestring
+            'tag': basestring
         },
         'line': basestring
     },
-    'messages': {
-        '*': {
+    'messages': [
+        {
+            # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+            # This may change if we are able to find a more well defined naming system.
+            'error': basestring,
+            'tag': basestring,
             'values': dict,
             'line': basestring,
             'model': basestring,
             'mapping': dict
         }
-    }
+    ]
 }

--- a/napalm_logs/config/iosxr.yml
+++ b/napalm_logs/config/iosxr.yml
@@ -7,11 +7,14 @@ prefix:
     time: (\d\d:\d\d:\d\d\.\d\d\d \w\w\w)
     processName: (\w+)
     processId: (\d+)
-    error: ([\w-]+)
-  line: '{messageId}: {host}:{date} {time}: {processName}[{processId}]: %{error}'
+    tag: ([\w-]+)
+  line: '{messageId}: {host}:{date} {time}: {processName}[{processId}]: %{tag}'
 
 messages:
-  ROUTING-BGP-5-MAXPFX:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: ROUTING-BGP-5-MAXPFX
+    tag: BGP_PREFIX_THRESH_EXCEEDED
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       current: (\d+)

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -7,11 +7,14 @@ prefix:
     host: ([^ ]+)
     processName: (\w+)
     processId: (\d+)
-    error: (\w+)
-  line: '{date} {time}  {host} {processName}[{processId}]: {error}: '
+    tag: (\w+)
+  line: '{date} {time}  {host} {processName}[{processId}]: {tag}: '
 
 messages:
-  BGP_PREFIX_THRESH_EXCEEDED:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: BGP_PREFIX_THRESH_EXCEEDED
+    tag: BGP_PREFIX_THRESH_EXCEEDED
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       asn: (\d+)


### PR DESCRIPTION
Some systems use the same syslog error for different issues, i.e an
Arista device uses `%BGP-3-NOTIFICATION` for several different BGP 
logs.

We may also need to use different regex for different IP versions or
similar.

I understand that the code to check the config is becoming a little
unruly, but it does work. Maybe we can clean it up later once the final
config format has been decided on. 