### PR TITLE
Add static mappings

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -141,7 +141,7 @@ class NapalmLogs:
 
     def _verify_config_key(self, key, value, valid, config, dev_os, key_path):
         key_path.append(key)
-        if not config.get(key):
+        if config.get(key, False) is False:
             self._raise_config_exception('Unable to find key "{}" for {}'.format(':'.join(key_path), dev_os))
         if isinstance(value, type):
             if not isinstance(config[key], value):

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -47,7 +47,10 @@ VALID_CONFIG = {
             'values': dict,
             'line': basestring,
             'model': basestring,
-            'mapping': dict
+            'mapping': {
+                'variables': dict,
+                'static': dict
+                }
         }
     ]
 }

--- a/napalm_logs/config/eos.yml
+++ b/napalm_logs/config/eos.yml
@@ -20,4 +20,7 @@ messages:
     line: 'received from neighbor {peer} (AS {asn}) 6/1 (Cease/maximum number of prefixes reached) 0 bytes'
     model: openconfig_bgp
     mapping:
-      asn: bgp/neighbors/neighbor/{peer}/state/peer_as
+      variables:
+        bgp/neighbors/neighbor/{peer}/state/peer_as: asn
+      static:
+        bgp/neighbors/neighbor/{peer}/state/session_state: IDLE

--- a/napalm_logs/config/iosxr.yml
+++ b/napalm_logs/config/iosxr.yml
@@ -22,5 +22,7 @@ messages:
     line: 'No. of IPv4 Unicast prefixes received from {peer} has reached {current}, max {limit}'
     model: openconfig_bgp
     mapping:
-      limit: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/inet/ipv4_unicast/prefix_limit/state/max_prefixes
-      current: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/inet/state/prefixes/received
+      variables:
+        limit: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/inet/ipv4_unicast/prefix_limit/state/max_prefixes
+        current: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/inet/state/prefixes/received
+      static: {}

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -5,10 +5,11 @@ prefix:
     date: (\w+ \d\d)
     time: (\d\d:\d\d:\d\d)
     host: ([^ ]+)
-    processName: (\w+)
-    processId: (\d+)
+    processName: /?(\w+)
+    # Most log lines have a process ID, however some do not
+    processId: \[?(\d+)?\]?
     tag: (\w+)
-  line: '{date} {time}  {host} {processName}[{processId}]: {tag}: '
+  line: '{date} {time}  {host} {processName}{processId}: {tag}: '
 
 messages:
   # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
@@ -25,6 +26,18 @@ messages:
     line: '{peer} (External AS {asn}): Configured maximum prefix-limit threshold({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:
-      asn: bgp/neighbors/neighbor/{peer}/state/peer_as
-      current: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/state/prefixes/received
-      limit: bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/ipv4_{type}/prefix_limit/state/max_prefixes
+      variables:
+        bgp/neighbors/neighbor/{peer}/state/peer_as: asn
+        bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/state/prefixes/received: current
+        bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/ipv4_{type}/prefix_limit/state/max_prefixes: limit
+      static: {}
+  - error: BGP_MD5_INCORRECT
+    tag: tcp_auth_ok
+    values:
+      peer: (\d+\.\d+\.\d+\.\d+)
+    line: 'Packet from {peer}:179 missing MD5 digest'
+    model: openconfig_bgp
+    mapping:
+      variables: {}
+      static:
+        bgp/neighbors/neighbor/{peer}/state/session_state: CONNECT

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -199,8 +199,10 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             raise UnknownOpenConfigModel(error_string)
 
         oc_dict = {}
-        for result_key, mapping in kwargs['oc_mapping'].items():
+        for mapping, result_key in kwargs['oc_mapping']['variables'].items():
             result = kwargs[result_key]
+            oc_dict = self._setval(mapping.format(**kwargs), result, oc_dict)
+        for mapping, result in kwargs['oc_mapping']['static'].items():
             oc_dict = self._setval(mapping.format(**kwargs), result, oc_dict)
         try:
             oc_obj.load_dict(oc_dict)


### PR DESCRIPTION
Previously we only had mappings where the value was pulled stright from
the syslog message. However sometimes we will need to add static
mappings, i.e in the examples that I have added for `junos` and `eos`,
in the `junos` example when a MD5 sum is incorrect we know that the
session is not established so can set it accordingly.

I have changed the order of the mappings from `{result: oc_mapping}` to
`{oc_mapping: result}` as the result does not need to be unique, but the
mapping does, with the result as the key if two mappings had the same
key, one would be overwritten.

I also changes the config check to allow for an empty dict.