### PR TITLE
Add replace functionality to manipulate a syslog variable

### DIFF
--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -44,6 +44,7 @@ VALID_CONFIG = {
             'error': basestring,
             'tag': basestring,
             'values': dict,
+            'replace': dict,
             'line': basestring,
             'model': basestring,
             'mapping': {
@@ -58,7 +59,7 @@ VALID_CONFIG = {
 BUFFER_SIZE = 1024
 
 # device
-DEFAULT_DELIM = '/'
+DEFAULT_DELIM = '//'
 
 # auth
 AUTH_MAX_CONN = 5
@@ -66,3 +67,9 @@ AUTH_TIMEOUT = 5
 MAGIC_ACK = 'ACK'
 MAGIC_REQ = 'INIT'
 AUTH_CIPHER = 'ECDHE-RSA-AES256-GCM-SHA384'
+
+# replacement lambdas
+REPLACEMENTS = {
+    'uppercase': lambda var: var.upper(),
+    'lowercase': lambda var: var.lower()
+    }

--- a/napalm_logs/config/eos.yml
+++ b/napalm_logs/config/eos.yml
@@ -17,6 +17,7 @@ messages:
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       asn: (\d+)
+    replace: {}
     line: 'received from neighbor {peer} (AS {asn}) 6/1 (Cease/maximum number of prefixes reached) 0 bytes'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/iosxr.yml
+++ b/napalm_logs/config/iosxr.yml
@@ -19,6 +19,7 @@ messages:
       peer: (\d+\.\d+\.\d+\.\d+)
       current: (\d+)
       limit: (\d+)
+    replace: {}
     line: 'No. of IPv4 Unicast prefixes received from {peer} has reached {current}, max {limit}'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -23,21 +23,43 @@ messages:
       current: (\d+)
       table: (\w+)
       type: (\w+)
+    replace: {}
     line: '{peer} (External AS {asn}): Configured maximum prefix-limit threshold({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:
       variables:
-        bgp/neighbors/neighbor/{peer}/state/peer_as: asn
-        bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/state/prefixes/received: current
-        bgp/neighbors/neighbor/{peer}/afi_safis/afi_safi/{table}/ipv4_{type}/prefix_limit/state/max_prefixes: limit
+        bgp//neighbors//neighbor//{peer}//state//peer_as: asn
+        bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
+        bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv4_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
+    replace: {}
   - error: BGP_MD5_INCORRECT
     tag: tcp_auth_ok
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
+    replace: {}
     line: 'Packet from {peer}:179 missing MD5 digest'
     model: openconfig_bgp
     mapping:
       variables: {}
       static:
-        bgp/neighbors/neighbor/{peer}/state/session_state: CONNECT
+        bgp//neighbors//neighbor//{peer}//state//session_state: CONNECT
+  - error: SNMP_TRAP_LINK_DOWN
+    tag: SNMP_TRAP_LINK_DOWN
+    values:
+      snmpID: (\d+)
+      adminStatusString: (\w+)
+      adminStatusValue: (\d)
+      operStatusString: (\w+)
+      operStatusValue: (\d)
+      interface: ([\w\-\/]+)
+    replace:
+      adminStatusString: uppercase
+      operStatusString: uppercase
+    line: 'ifIndex {snmpID}, ifAdminStatus {adminStatusString}({adminStatusValue}), ifOperStatus {operStatusString}({operStatusValue}), ifName {interface}'
+    model: openconfig_interfaces
+    mapping:
+      variables:
+        interfaces//interface//{interface}//state//admin_status: adminStatusString
+        interfaces//interface//{interface}//state//oper_status: operStatusString
+      static: {}


### PR DESCRIPTION
The adds the ability to replace / transform a variable that is pulled
from the syslog message.

The example  that caused this to be added is `SNMP_TRAP_LINK_DOWN` for
`junos`. The openconfig model expects the value to be uppercase, but the
syslog message presents it in lowercase, therefore we need to be able to
replace `down` with `DOWN`.

I also had to change the delimeter as we had to set the interface name
within the mapping, and the interface name contained `/`