### PR TITLE
Add optional security to solve #43

### DIFF
--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -33,11 +33,13 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
                  transport_type,
                  private_key,
                  signing_key,
-                 pipe):
+                 pipe,
+                 disable_security=False):
         self.__pipe = pipe
         self.__up = False
         self.address = address
         self.port = port
+        self.disable_security = disable_security
         self._transport_type = transport_type
         self.__safe = nacl.secret.SecretBox(private_key)
         self.__signing_key = signing_key
@@ -78,7 +80,10 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
             to_publish = self.__pipe.recv()
             log.debug('Publishing object:')
             log.debug(to_publish)
-            prepared_obj = self._prepare(to_publish)
+            if self.disable_security is True:
+                prepared_obj = umsgpack.packb(to_publish)
+            else:
+                prepared_obj = self._prepare(to_publish)
             self.transport.publish(prepared_obj)
 
     def stop(self):

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -134,12 +134,19 @@ class NLOptionParser(OptionParser, object):
         self.add_option(
             '--certificate',
             dest='certificate',
-            help=('[REQUIRED] Absolute path to the SSL certificate used for client authentication.')
+            help=('Absolute path to the SSL certificate used for client authentication.')
         )
         self.add_option(
             '--keyfile',
             dest='keyfile',
             help=('Absolute path to the SSL keyfile')
+        )
+        self.add_option(
+            '--disable-security',
+            dest='disable_security',
+            action="store_true",
+            default=False,
+            help=('Disable encryption and data signing when publishing.')
         )
         self.add_option(
             '-l', '--log-level',
@@ -189,7 +196,7 @@ class NLOptionParser(OptionParser, object):
             log.removeHandler(screen_handler)  # remove printing to the screen
             logging.basicConfig(filename=log_file)  # log to file
         cert = self.options.certificate or file_cfg.get('certificate')
-        if not cert:
+        if not cert and self.options.disable_security is False:
             log.error('certfile must be specified for server-side operations')
             raise ValueError('Please specify a valid SSL certificate.')
         cfg = {
@@ -206,6 +213,7 @@ class NLOptionParser(OptionParser, object):
                             or defaults.AUTH_PORT,
             'certificate': cert,
             'keyfile': self.options.keyfile or file_cfg.get('keyfile'),
+            'disable_security': self.options.disable_security or file_cfg.get('disable_security'),
             'config_path': self.options.config_path or file_cfg.get('config_path'),
             'extension_config_path': self.options.extension_config_path or file_cfg.get('extension_config_path'),
             'log_level': self.options.log_level or file_cfg.get('log_level') or defaults.LOG_LEVEL,

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -78,3 +78,11 @@ def decrypt(binary, verify_key_obj, private_key_obj):
         log.error('Unable to decrypt', exc_info=True)
         raise CryptoException('Unable to decrypt')
     return umsgpack.unpackb(packed)
+
+def unserialize(binary):
+    '''
+    Unpack the original OpenConfig object,
+    serialized using MessagePack.
+    This is to be used when disable_security is set.
+    '''
+    return umsgpack.unpackb(binary)


### PR DESCRIPTION
Add an option to disable encryption and signing. This is for cases when
people would only need to send the data as-is to a log server etc. It
could also be useful for testing purposes.