### PR TITLE
Check that the cert and key are present and valid issue #50

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -288,6 +288,7 @@ class NapalmLogs:
                                       priv_key,
                                       sgn_verify_hex,
                                       auth_skt)
+            auth.verify_cert()
             self.pauth = Process(target=auth.start)
             self.pauth.start()
         log.info('Starting the publisher process')

--- a/napalm_logs/exceptions.py
+++ b/napalm_logs/exceptions.py
@@ -63,3 +63,10 @@ class BadSignatureException(NapalmLogsException):
     Raised when the signature was forged or corrupted.
     '''
     pass
+
+
+class SSLMismatchException(NapalmLogsException):
+    '''
+    Raised when the SSL certificate and key do not match
+    '''
+    pass


### PR DESCRIPTION
Current the napalm-logs process will start correctly even if the cert
and key are either not present or do not match. Then it will error when
a client tries to subscribe.

This PR adds a check when starting to make sure the files are present
and that the key and cert match.