### PR TITLE
Allow 1 whitespace to match many whitespaces

### DIFF
--- a/napalm_logs/config/eos.yml
+++ b/napalm_logs/config/eos.yml
@@ -1,4 +1,8 @@
 # You should not use special characture in the value keys
+#
+# A single whitespace in `line` will match any number of whitespaces. You should be explicit when
+# Matching white space in `values`
+#
 prefix:
   time_format: "%b %d %H:%M:%S"
   values:

--- a/napalm_logs/config/iosxr.yml
+++ b/napalm_logs/config/iosxr.yml
@@ -1,4 +1,8 @@
 # You should not use special characture in the value keys
+#
+# A single whitespace in `line` will match any number of whitespaces. You should be explicit when
+# Matching white space in `values`
+#
 prefix:
   values:
     messageId: (\d+)

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -1,8 +1,12 @@
 # You should not use special characture in the value keys
+#
+# A single whitespace in `line` will match any number of whitespaces. You should be explicit when
+# Matching white space in `values`
+#
 prefix:
   time_format: "%b %d %H:%M:%S"
   values:
-    date: (\w+ \d\d)
+    date: (\w+\s+\d+)
     time: (\d\d:\d\d:\d\d)
     host: ([^ ]+)
     processName: /?(\w+)

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -80,6 +80,8 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                 sorted_position[elem[1]] = i + 1
             # Escape the line, then remove the escape for the curly bracets so they can be used when formatting
             escaped = re.escape(line).replace('\{', '{').replace('\}', '}')
+            # Replace a whitespace with \s+
+            escaped = escaped.replace('\ ', '\s+')
             self.compiled_messages.append(
                 {
                     'error': error,

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -76,6 +76,8 @@ class NapalmLogsServerProc(NapalmLogsProc):
                 sorted_position[elem[1]] = i + 1
             # Escape the line, then remove the escape for the curly bracets so they can be used when formatting
             escaped = re.escape(line).replace('\{', '{').replace('\}', '}')
+            # Replace a whitespace with \s+
+            escaped = escaped.replace('\ ', '\s+')
             self.compiled_prefixes[dev_os] = {
                 'prefix': re.compile(escaped.format(**values)),
                 'prefix_positions': sorted_position,


### PR DESCRIPTION
The format of syslog messages can change, especially the amount of
whitespace, for example in Junos the date can be shown as:

```
May  4 11:04:38
```
Or
```
May 14 11:04:38
```

This change makes it so 1 whitespace in `line` will match any number of
whitespaces. You do still need to be explicit when matching whitespaces
in `values`

This is linked to #65