### PR TITLE
Firstly install the pyangbind patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pyzmq
 pyyaml
 pynacl
 u-msgpack-python
-napalm-yang
 -e git://github.com/napalm-automation/pyangbind.git@napalm_custom#egg=pyangbind
+napalm-yang


### PR DESCRIPTION
And only afterwards the napalm-yang library.
Doing so, we can make sure that it installs
either the patch first, either a newer official
release.