### PR TITLE
Add IPv6 option for zeromq publish address

### DIFF
--- a/napalm_logs/transport/zeromq.py
+++ b/napalm_logs/transport/zeromq.py
@@ -30,6 +30,8 @@ class ZMQTransport(TransportBase):
     def start(self):
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PUB)
+        if ':' in self.addr:
+            self.socket.ipv6 = True
         try:
             self.socket.bind('tcp://{addr}:{port}'.format(
                 addr=self.addr,


### PR DESCRIPTION
Currently if you use an IPv6 address to publish in ZMQ you get an error.
This PR adds a check for an IPv6 address and sets the socket to IPv6.