### PR TITLE
Update IOS-XR prefix to include host and node-id

### DIFF
--- a/napalm_logs/config/iosxr.yml
+++ b/napalm_logs/config/iosxr.yml
@@ -6,13 +6,18 @@
 prefix:
   values:
     messageId: (\d+)
-    host: ([^ ]+)
-    date: (\w+ \d\d)
+    # On IOS-XR syslog messages do not contain the hostname by default, they
+    # only provide the node-id which, e.g RP/0/RSP0/CPU0. To include the
+    # hostname you can add a hostname prefix, however as this is not always
+    # present the host field can be empty.
+    host: ([^ ]+ )?
+    nodeId: ([^ ]+)
+    date: (\w+ +\d+)
     time: (\d\d:\d\d:\d\d\.\d\d\d \w\w\w)
     processName: (\w+)
     processId: (\d+)
     tag: ([\w-]+)
-  line: '{messageId}: {host}:{date} {time}: {processName}[{processId}]: %{tag}'
+  line: '{messageId}: {host}{nodeId}:{date} {time}: {processName}[{processId}]: %{tag}'
 
 messages:
   # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.


### PR DESCRIPTION
The format of an IOS-XR syslog message is as follows:

```
node-id : timestamp : process-name [pid] : % message category -group
-severity -message -code : message-text
```

The node-id is of the form `RP/0/RP0/CPU0`, and doesn't indicate the
actual host that the message comes from. The only way that I can find to
get the hostname in there is by using a hostname prefix:

```
logging hostnameprefix <hostname>
```

This then produces a message as follows:

```
<149>12345678: edge01.aaa01 RP/0/RSP1/CPU0:Mar 28 15:08:30.941 UTC:
bgp[1051]: %ROUTING-BGP-5-MAXPFX : No. of IPv4 Unicast prefixes received
from 1.2.3.4 has reached 100, max 110
```