### PR TITLE
Use PyPI for pyangbind

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pyzmq
 pyyaml
 pynacl
 u-msgpack-python
--e git://github.com/napalm-automation/pyangbind.git@napalm_custom#egg=pyangbind
+pyangbind
 napalm-yang


### PR DESCRIPTION
Now that https://github.com/robshakir/pyangbind/pull/118 has been merged
we can now use the version from PyPI