### PR TITLE
Disable openconfig cache due to #85

### DIFF
--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -226,8 +226,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         To reduce the overhead, caches the object in memory when
         generation is successful.
         '''
-        if model_name in self.__yang_cache:
-            return self.__yang_cache[model_name]
+        # FIXME Disabled cache due to issue #85
+        #if model_name in self.__yang_cache:
+        #    return self.__yang_cache[model_name]
         log.debug('YANG binding not cached yet, generating')
         oc_obj = napalm_yang.base.Root()
         try:

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -161,7 +161,7 @@ def main():
     cproc = Process(target=client, kwargs=config)
     cproc.start()
     for _ in range(config['routers']):
-        if config['protocol'] == 'tcp':
+        if config['listener'] == 'tcp':
             rproc = Process(target=router_tcp, args=(_,), kwargs=config)
         else:
             rproc = Process(target=router_udp, args=(_,), kwargs=config)


### PR DESCRIPTION
This is just a work around until a method is available to clear the OC
object.