### PR TITLE
Add v6 match for junos BGP_PREFIX_THRESH_EXCEEDED

### DIFF
--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -37,6 +37,25 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv4_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
     replace: {}
+  - error: BGP_PREFIX_THRESH_EXCEEDED
+    tag: BGP_PREFIX_THRESH_EXCEEDED
+    values:
+      peer: ([\w\d:]+)
+      asn: (\d+)
+      limit: (\d+)
+      current: (\d+)
+      table: (\w+)
+      type: (\w+)
+    replace: {}
+    line: '{peer} (External AS {asn}): Configured maximum prefix-limit threshold({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
+    model: openconfig_bgp
+    mapping:
+      variables:
+        bgp//neighbors//neighbor//{peer}//state//peer_as: asn
+        bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
+        bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv6_{type}//prefix_limit//state//max_prefixes: limit
+      static: {}
+    replace: {}
   - error: BGP_MD5_INCORRECT
     tag: tcp_auth_ok
     values:


### PR DESCRIPTION
The OC model requires you to specify the `afi-safi-name`, which for ipv4
unicast is `ipv4-unicast`, and for ipv6 unicast is `ipv6-unicast`,
because `ipv4` or `ipv6` are not specified in the log message we are not
able to determine this with our current config. Therefore I am adding a
new error which will match the ipv6 address, and has `ipv6-` hardcoded
in the oc model.