### PR TITLE
Add an option to log all processed logs to syslog for storage

### DIFF
--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -22,8 +22,15 @@ LOG_LEVEL = 'warning'
 LOG_FORMAT = '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 LOG_FILE = os.path.join(ROOT_DIR, 'var', 'log', 'napalm', 'logs')
 LOG_FILE_CLI_OPTIONS = ('cli', 'screen')
-KAFKA_LISTENER_TOPIC = "syslog.net"
-KAFKA_PUBLISHER_TOPIC = "napalm-logs"
+LISTENER_OPTS = {
+    'kafka_topic': 'syslog.net',
+    }
+LOGGER_OPTS = {
+    'kafka_topic': 'syslog.net.processed'
+    }
+PUBLISHER_OPTS = {
+    'kafka_topic': 'napalm-logs'
+    }
 
 LOGGING_LEVEL = {
     'debug': logging.DEBUG,

--- a/napalm_logs/listener/base.py
+++ b/napalm_logs/listener/base.py
@@ -8,7 +8,7 @@ class ListenerBase:
     '''
     The base class for the listener.
     '''
-    def __init__(self, addr, port):
+    def __init__(self, address, port, **kwargs):
         pass
 
     def start(self):

--- a/napalm_logs/listener/tcp.py
+++ b/napalm_logs/listener/tcp.py
@@ -29,9 +29,15 @@ class TCPListener(ListenerBase):
     '''
     TCP syslog listener class
     '''
-    def __init__(self, address, port, pipe):
-        self.address = address
-        self.port = port
+    def __init__(self, address, port, pipe, **kwargs):
+        if kwargs.get('address'):
+            self.address = kwargs['address']
+        else:
+            self.address = address
+        if kwargs.get('port'):
+            self.port = kwargs['port']
+        else:
+            self.port = port
         self.pipe = pipe
         self.__up = False
 
@@ -74,7 +80,7 @@ class TCPListener(ListenerBase):
         self.__up = True
         self.skt = self._open_socket(socket.SOCK_STREAM)
         try:
-            self.skt.bind((self.address, self.port))
+            self.skt.bind((self.address, int(self.port)))
         except socket.error as msg:
             error_string = 'Unable to bind to port {} on {}: {}'.format(self.port, self.address, msg)
             log.error(error_string, exc_info=True)

--- a/napalm_logs/listener/udp.py
+++ b/napalm_logs/listener/udp.py
@@ -27,9 +27,15 @@ class UDPListener(ListenerBase):
     '''
     UDP syslog listener class
     '''
-    def __init__(self, address, port, pipe):
-        self.address = address
-        self.port = port
+    def __init__(self, address, port, pipe, **kwargs):
+        if kwargs.get('address'):
+            self.address = kwargs['address']
+        else:
+            self.address = address
+        if kwargs.get('port'):
+            self.port = kwargs['port']
+        else:
+            self.port = port
         self.pipe = pipe
         self.__up = False
 
@@ -55,7 +61,7 @@ class UDPListener(ListenerBase):
         self.__up = True
         self.skt = self._open_socket(socket.SOCK_DGRAM)
         try:
-            self.skt.bind((self.address, self.port))
+            self.skt.bind((self.address, int(self.port)))
         except socket.error as msg:
             error_string = 'Unable to bind to port {} on {}: {}'.format(self.port, self.address, msg)
             log.error(error_string, exc_info=True)

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -38,6 +38,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
                  pipe,
                  private_key,
                  signing_key,
+                 publisher_opts,
                  disable_security=False):
         self.__up = False
         self.address = address
@@ -45,6 +46,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         self.pipe = pipe
         self.disable_security = disable_security
         self._transport_type = transport_type
+        self.publisher_opts = publisher_opts
         if not disable_security:
             self.__safe = nacl.secret.SecretBox(private_key)
             self.__signing_key = signing_key
@@ -71,7 +73,8 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         '''
         transport_class = get_transport(self._transport_type)
         self.transport = transport_class(self.address,
-                                         self.port)
+                                         self.port,
+                                         **self.publisher_opts)
 
     def _prepare(self, obj):
         '''

--- a/napalm_logs/transport/base.py
+++ b/napalm_logs/transport/base.py
@@ -8,7 +8,7 @@ class TransportBase:
     '''
     The base class for the transport.
     '''
-    def __init__(self, addr, port):
+    def __init__(self, addr, port, **kwargs):
         pass
 
     def start(self):

--- a/napalm_logs/transport/kafka.py
+++ b/napalm_logs/transport/kafka.py
@@ -19,7 +19,6 @@ except ImportError as err:
 # Import napalm-logs pkgs
 from napalm_logs.exceptions import NapalmLogsException
 from napalm_logs.transport.base import TransportBase
-from napalm_logs.config import KAFKA_PUBLISHER_TOPIC
 
 log = logging.getLogger(__name__)
 
@@ -28,9 +27,16 @@ class KafkaTransport(TransportBase):
     '''
     Kafka transport class.
     '''
-    def __init__(self, addr, port):
-        self.bootstrap_servers = '{addr}:{port}'.format(addr=addr, port=port)
-        self.topic = KAFKA_PUBLISHER_TOPIC
+    def __init__(self, address, port, **kwargs):
+        if kwargs.get('address'):
+            address = kwargs['address']
+        if kwargs.get('port'):
+            address = kwargs['port']
+        if kwargs.get('bootstrap_servers'):
+            self.bootstrap_servers = kwargs['bootstrap_servers']
+        else:
+            self.bootstrap_servers = '{}:{}'.format(address, port)
+        self.kafka_topic = kwargs['kafka_topic']
 
     def start(self):
         try:
@@ -40,7 +46,7 @@ class KafkaTransport(TransportBase):
             raise NapalmLogsException(err)
 
     def publish(self, obj):
-        self.producer.send(self.topic, obj)
+        self.producer.send(self.kafka_topic, obj)
 
     def stop(self):
         if hasattr(self, 'producer'):

--- a/napalm_logs/transport/log.py
+++ b/napalm_logs/transport/log.py
@@ -19,14 +19,20 @@ class LogTransport(TransportBase):
     '''
     Log transport class.
     '''
-    def __init__(self, addr, port):
-        self.addr = addr
-        self.port = port
+    def __init__(self, address, port, **kwargs):
+        if kwargs.get('address'):
+            self.address = kwargs['address']
+        else:
+            self.address = address
+        if kwargs.get('port'):
+            self.port = kwargs['port']
+        else:
+            self.port = port
 
     def start(self):
         self.logger = logging.getLogger('napalm-logs')
         self.logger.setLevel(logging.INFO)
-        handler = logging.handlers.SocketHandler(self.addr, self.port)
+        handler = logging.handlers.SocketHandler(self.address, self.port)
         formatter = logging.Formatter('%(asctime)s: %(message)s')
         handler.setFormatter(formatter)
         self.logger.addHandler(handler)

--- a/napalm_logs/transport/zeromq.py
+++ b/napalm_logs/transport/zeromq.py
@@ -23,18 +23,24 @@ class ZMQTransport(TransportBase):
     '''
     ZMQ transport class.
     '''
-    def __init__(self, addr, port):
-        self.addr = addr
-        self.port = port
+    def __init__(self, address, port, **kwargs):
+        if kwargs.get('address'):
+            self.address = kwargs['address']
+        else:
+            self.address = address
+        if kwargs.get('port'):
+            self.port = kwargs['port']
+        else:
+            self.port = port
 
     def start(self):
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PUB)
-        if ':' in self.addr:
+        if ':' in self.address:
             self.socket.ipv6 = True
         try:
             self.socket.bind('tcp://{addr}:{port}'.format(
-                addr=self.addr,
+                addr=self.address,
                 port=self.port)
             )
         except zmq.error.ZMQError as err:


### PR DESCRIPTION
I assume that most people will want to store their logs after they have
been processed / acted on for auditing purposes. They could either have
a different syslog server on the network device, or forward the log
messages on from here. If they forward the messages on from here there
is the benefit of them having been parsed and the device OS being
determind.

Rather than add a new `logger` classs, I decided to use the transport
class again. In doing so I needed a way to pass different options to the
transport class based on where it was being called from, whilst still
keeping it completely plugable. Therefore I have added a `plugable`
section to the config which you can add specific options for the
plugable modules which can change deplendent on where they are called
from.