### PR TITLE
Add whitespace as a possible match in junos tag

### DIFF
--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -13,7 +13,7 @@ prefix:
     processName: /?(\w+)
     # Most log lines have a process ID, however some do not
     processId: \[?(\d+)?\]?
-    tag: (\w+)
+    tag: ([\w\s]+)
   line: '{date} {time} {hostPrefix}{host} {processName}{processId}: {tag}: '
 
 messages:


### PR DESCRIPTION
Currently we are only matching `\w` for a `junos` tag, however it seems
it is possible for the tag to have a space in it:

```
<7>Jul 5 11:47:10 vmx01 kernel: rts_commit_proposalmput op:
2, peer_type:17, peer_index:0, vskid:0, seqno:12345, flag:9,
```