### PR TITLE
Add ability to have user defined models when OC is not appropriate

### DIFF
--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -103,3 +103,5 @@ REPLACEMENTS = {
     'uppercase': lambda var: var.upper(),
     'lowercase': lambda var: var.lower()
 }
+
+OPEN_CONFIG_NO_MODEL = 'NO_MODEL'

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -38,7 +38,6 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv4_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
-    replace: {}
   - error: BGP_PREFIX_THRESH_EXCEEDED
     tag: BGP_PREFIX_THRESH_EXCEEDED
     values:
@@ -58,7 +57,6 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv6_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
-    replace: {}
   - error: BGP_PREFIX_LIMIT_EXCEEDED
     tag: BGP_PREFIX_LIMIT_EXCEEDED
     values:
@@ -78,7 +76,6 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv4_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
-    replace: {}
   - error: BGP_PREFIX_LIMIT_EXCEEDED
     tag: BGP_PREFIX_LIMIT_EXCEEDED
     values:
@@ -98,7 +95,17 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv6_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
+  - error: USER_ENTER_CONFIG_MODE
+    tag: UI_DBASE_LOGIN_EVENT
+    values:
+      user: (\w+)
     replace: {}
+    line: User '{user}' entering configuration mode
+    model: NO_MODEL
+    mapping:
+      variables: {}
+      static:
+        users//user//{user}//action//enter_config_mode: True
   - error: BGP_MD5_INCORRECT
     tag: tcp_auth_ok
     values:

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -23,6 +23,7 @@ from napalm_logs.config import PUB_IPC_URL
 from napalm_logs.config import DEV_IPC_URL_TPL
 from napalm_logs.config import DEFAULT_DELIM
 from napalm_logs.config import REPLACEMENTS
+from napalm_logs.config import OPEN_CONFIG_NO_MODEL
 from napalm_logs.exceptions import OpenConfigPathException
 from napalm_logs.exceptions import UnknownOpenConfigModel
 # exceptions
@@ -246,16 +247,21 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         Emit an OpenConfig object given a certain combination of
         fields mappeed in the config to the corresponding hierarchy.
         '''
-        # Load the appropriate OC model
-        log.debug('Getting the YANG model binding')
-        oc_obj = self._get_oc_obj(kwargs['oc_model'])
-        log.debug('Filling the OC model')
         oc_dict = {}
         for mapping, result_key in kwargs['oc_mapping']['variables'].items():
             result = kwargs[result_key]
             oc_dict = self._setval(mapping.format(**kwargs), result, oc_dict)
         for mapping, result in kwargs['oc_mapping']['static'].items():
             oc_dict = self._setval(mapping.format(**kwargs), result, oc_dict)
+
+        # Check if OC model is set to NO_MODEL
+        if kwargs['oc_model'] == OPEN_CONFIG_NO_MODEL:
+            return oc_dict
+
+        # Load the appropriate OC model
+        log.debug('Getting the YANG model binding')
+        oc_obj = self._get_oc_obj(kwargs['oc_model'])
+        log.debug('Filling the OC model')
         try:
             oc_obj.load_dict(oc_dict)
         except AttributeError:


### PR DESCRIPTION
We are trying to use OpenConfig models where possible. However sometimes
it is not possible to use OpenConfig. One example is the error added
here:

```
Jun  9 08:42:29  vmx01 mgd[19896]: UI_DBASE_LOGIN_EVENT: User 'luke'
entering configuration mode
```

I have addee the ability to specify ``NO_MODEL``, which will then just
use the model as defined in the configuration file.

N.B This should only be used when OS isn't appropriate for the message.
Where possible we should add new OC models.