### PR TITLE
Add error BGP_PEER_NOT_CONFIGURED

### DIFF
--- a/docs/messages/BGP_PEER_NOT_CONFIGURED.rst
+++ b/docs/messages/BGP_PEER_NOT_CONFIGURED.rst
@@ -1,0 +1,51 @@
+=======================
+BGP_PEER_NOT_CONFIGURED
+=======================
+
+This error tag corresponds to syslog messages notifying that the configured peer sent a BGP notification code 6 subcode 5, which idicates that the peer does not have the session configured.
+
+Maps to the ``openconfig_bgp`` YANG model.
+
+Implemented for:
+
+- junos
+
+Example:
+
+.. code-block:: json
+
+	{
+	  "message_details": {
+		"processId": "1848",
+		"hostPrefix": null,
+		"pri": "28",
+		"processName": "rpd",
+		"host": "vmx01",
+		"tag": "bgp_read_message",
+		"time": "05:52:44",
+		"date": "Jul  5",
+		"message": "2764: NOTIFICATION received from 1.2.3.4 (External AS 1234): code 6 (Cease) subcode 5 (Connection Rejected)"
+	  },
+	  "open_config": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "1.2.3.4": {
+				"state": {
+				  "session_state": "ACTIVE",
+				  "peer_as": 1234
+				},
+				"neighbor_address": "1.2.3.4"
+			  }
+			}
+		  }
+		}
+	  },
+	  "ip": "127.0.0.1",
+	  "error": "BGP_PEER_NOT_CONFIGURED",
+	  "host": "vmx01",
+	  "timestamp": "1499230364",
+	  "os": "junos",
+	  "model_name": "openconfig_bgp"
+	}
+

--- a/docs/messages/index.rst
+++ b/docs/messages/index.rst
@@ -75,3 +75,4 @@ Under this section, we present the possible error tags, together with their corr
    BGP_MD5_INCORRECT
    BGP_PREFIX_THRESH_EXCEEDED
    BGP_PREFIX_LIMIT_EXCEEDED
+   BGP_PEER_NOT_CONFIGURED

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -14,11 +14,25 @@ prefix:
     # Most log lines have a process ID, however some do not
     processId: \[?(\d+)?\]?
     tag: ([\w\s]+)
-  line: '{date} {time} {hostPrefix}{host} {processName}{processId}: {tag}: '
+  line: '{date} {time} {hostPrefix}{host} {processName}{processId}: {tag}:'
 
 messages:
   # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
   # This may change if we are able to find a more well defined naming system.
+  - error: BGP_PEER_NOT_CONFIGURED
+    tag: bgp_read_message
+    values:
+      peer: ([\w\d:\.]+)
+      asn: (\d+)
+      number: (\d+)
+    replace: {}
+    line: '{number}: NOTIFICATION received from {peer} (External AS {asn}): code 6 (Cease) subcode 5 (Connection Rejected)'
+    model: openconfig_bgp
+    mapping:
+      variables:
+        bgp//neighbors//neighbor//{peer}//state//peer_as: asn
+      static:
+        bgp//neighbors//neighbor//{peer}//state//session_state: ACTIVE
   - error: BGP_PREFIX_THRESH_EXCEEDED
     tag: BGP_PREFIX_THRESH_EXCEEDED
     values:

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -111,6 +111,8 @@ class NapalmLogsServerProc(NapalmLogsProc):
             ret = {}
             for key in values.keys():
                 ret[key] = match.group(positions.get(key))
+            # Remove whitespace from the start or end of the message
+            ret['message'] = ret['message'].strip()
             # TODO Should we stop searching and just return, or should we return all matches OS?
             return dev_os, ret
         log.debug('No OS matched for: {}'.format(msg))


### PR DESCRIPTION
The format of this error for `junos` is a little different from others:

```
<87>Jul  5 05:52:44  vmx01 rpd[1848]: bgp_read_message:2764:
NOTIFICATION received from 1.2.3.4 (External AS 1234): code 6 (Cease)
subcode 5 (Connection Rejected)
```

Where you would normally find the tag, we have `bgp_read_message:2764`,
or `2764` could be part of the message, either way it is not standard.

Therefore I have changed the prefix config to not have the whitespace at
the end of the prefix `line`. Along with this I have removed any
whitespace from the beginning (and end) of the message line as most
messages would have a space at the start.