### PR TITLE
Speed improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ YAML configuration file.
 Requirements
 ------------
 
-- [napalm-yang](https://github.com/napalm-automation/napalm-yang)
 - PyYAML
 - pyzmq
 

--- a/napalm_logs/exceptions.py
+++ b/napalm_logs/exceptions.py
@@ -37,13 +37,6 @@ class ConfigurationException(NapalmLogsException):
     pass
 
 
-class UnknownOpenConfigModel(NapalmLogsException):
-    '''
-    Unable to log a model via napalm-yang
-    '''
-    pass
-
-
 class OpenConfigPathException(NapalmLogsException):
     '''
     Unable to set the open config path specified.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ pyzmq
 pyyaml
 pynacl
 u-msgpack-python
--e git://github.com/napalm-automation/pyangbind.git@napalm_custom#egg=pyangbind
-napalm-yang

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -85,13 +85,17 @@ def client(**config):
     '''
     Start the client and listen to messages.
     '''
-    pk, vk = napalm_logs.utils.authenticate(config['certificate'])
     context = zmq.Context()
     sock = context.socket(zmq.SUB)
     sock.connect('tcp://{addr}:{port}'.format(
         addr=config['publish_address'],
         port=config['publish_port']))
     sock.setsockopt(zmq.SUBSCRIBE, '')
+
+    auth = napalm_logs.utils.ClientAuth(config['certificate'],
+                                        address=config['auth_address'],
+                                        port=config['auth_port'])
+
     heat_stop = time.time() + config['heat_time']
     stop_time = time.time() + config['run_time']
     count = 0
@@ -102,7 +106,7 @@ def client(**config):
         obj = sock.recv()
         log.debug('Received:')
         log.debug(obj)
-        decrypted = napalm_logs.utils.decrypt(obj, vk, pk)
+        decrypted = auth.decrypt(obj)
         log.debug('Decrypted:')
         log.debug(decrypted)
         count += 1


### PR DESCRIPTION
5f7b597:

Previously we were loading the default OC object each time, however
as we do not use any of the defaults there isn't much point as it
drastically slows things down.

Another benefit of loading it each time is to make sure the OC object is
correctly defined, however this does not need to be done every time.
Therefore in future it should be checked manually before submitting /
accepting new message config.

Before the change:

```
Sent 735140 messages in 60 seconds
Sent 736409 messages in 60 seconds
Sent 744102 messages in 60 seconds
Sent 740599 messages in 60 seconds
Sent 742752 messages in 60 seconds
Received 470 messages in 50 seconds
```

After te change:

```
Sent 584443 messages in 60 seconds
Sent 587113 messages in 60 seconds
Sent 576232 messages in 60 seconds
Sent 582314 messages in 60 seconds
Sent 575888 messages in 60 seconds
Received 106044 messages in 50 seconds
```

1a9aff2:

In #87 we changed the auth method, but the test was missed.
