### PR TITLE
Add logger option to specify the transport to use

### DIFF
--- a/docs/options/index.rst
+++ b/docs/options/index.rst
@@ -446,12 +446,23 @@ Example:
   listener_opts:
     kafka_topic: napalm-logs-in
 
+.. _logger:
+
+``logger``
+++++++++++
+
+The logger subsystem uses the modules from the publisher pluggable subsystem to send partially parsed syslog messages.
+
+.. code-block:: yaml
+
+  logger: kafka
+
 .. _logger-opts:
 
 ``logger_opts``
 +++++++++++++++
 
-The logger subsystem uses the modules from the publisher pluggable subsystem to sent partially parsed syslog messages, that either couldn't detect the network operating system, either there isn't a profile mapping available.
+Configuration options for the logger module used to send partially parsed syslog messages.
 
 .. _logger-opts-bootstrap-servers:
 

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -58,6 +58,7 @@ class NapalmLogs:
                  log_level='warning',
                  log_format='%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s',
                  listener_opts={},
+                 logger=None,
                  logger_opts={},
                  publisher_opts={},
                  device_blacklist=[],
@@ -90,6 +91,7 @@ class NapalmLogs:
         self.log_level = log_level
         self.log_format = log_format
         self.listener_opts = listener_opts
+        self.logger = logger
         self.logger_opts = logger_opts
         self.publisher_opts = publisher_opts
         self.device_whitelist = device_whitelist
@@ -329,6 +331,7 @@ class NapalmLogs:
         server = NapalmLogsServerProc(self.config_dict,
                                       pipe,
                                       os_pipes,
+                                      self.logger,
                                       self.logger_opts,
                                       self.publisher_opts)
         proc = Process(target=server.start)

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -272,6 +272,7 @@ class NLOptionParser(OptionParser, object):
             'log_level': log_lvl,
             'log_format': log_fmt,
             'listener_opts': listener_opts,
+            'logger': file_cfg.get('logger'),
             'logger_opts': logger_opts,
             'publisher_opts': publisher_opts,
             'device_whitelist': device_whitelist,


### PR DESCRIPTION
Previously we were specifying the transport to use via the `syslog`
option, this PR adds a `logger` option to replace the `syslog` option as
it makes more sense.