### PR TITLE
Remove CLI log-level default

### DIFF
--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -158,7 +158,6 @@ class NLOptionParser(OptionParser, object):
         )
         self.add_option(
             '-l', '--log-level',
-            default='warning',
             dest='log_level',
             help=('Logging level. Default: {0}'.format(defaults.LOG_LEVEL))
         )


### PR DESCRIPTION
So it considers the `log_level` field from the config file, when starting as system process.