### PR TITLE
Add new error SYSTEM_ALARM

### DIFF
--- a/docs/messages/SYSTEM_ALARM.rst
+++ b/docs/messages/SYSTEM_ALARM.rst
@@ -1,0 +1,52 @@
+============
+SYSTEM_ALARM
+============
+
+This error tag corresponds to syslog messages notifying that there has been a change in status for an alarm.
+
+There are multiple entries for this error. The reason being that the exact component name can be contained in the reason section, so has to be extracted via a specific regex.
+
+Maps to the ``ietf-hardware`` YANG model.
+
+Implemented for:
+
+- junos
+
+Example:
+
+.. code-block:: json
+
+	{
+	  "yang_message": {
+		"hardware-state": {
+		  "component": {
+			"FPC 0": {
+			  "state": {
+				"alarm-reason": "FPC 0 Major Errors",
+				"alarm-state": 3
+			  },
+			  "name": "FPC 0",
+			  "class": "CHASSIS"
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": "2449",
+		"hostPrefix": null,
+		"pri": "29",
+		"processName": "alarmd",
+		"host": "vmx01",
+		"tag": "Alarm set",
+		"time": "23:04:13",
+		"date": "Jul  8",
+		"message": "FPC color=RED, class=CHASSIS, reason=FPC 0 Major Errors"
+	  },
+	  "timestamp": "1499551453",
+	  "ip": "127.0.0.1",
+	  "host": "vmx01",
+	  "yang_model": "ietf-hardware",
+	  "error": "SYSTEM_ALARM",
+	  "os": "junos"
+	}
+

--- a/docs/messages/index.rst
+++ b/docs/messages/index.rst
@@ -77,4 +77,5 @@ Under this section, we present the possible error tags, together with their corr
    BGP_PREFIX_LIMIT_EXCEEDED
    BGP_PEER_NOT_CONFIGURED
    RAW
+   SYSTEM_ALARM
    UNKNOWN

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -103,10 +103,17 @@ MAGIC_ACK = 'ACK'
 MAGIC_REQ = 'INIT'
 AUTH_CIPHER = 'ECDHE-RSA-AES256-GCM-SHA384'
 
+OPEN_CONFIG_NO_MODEL = 'NO_MODEL'
+
 # replacement lambdas
 REPLACEMENTS = {
     'uppercase': lambda var: var.upper(),
-    'lowercase': lambda var: var.lower()
+    'lowercase': lambda var: var.lower(),
+    'color_to_severity': lambda var: _COLOR_TO_severity.get(var, 0)
 }
 
-OPEN_CONFIG_NO_MODEL = 'NO_MODEL'
+# For use with replacement lamdas
+_COLOR_TO_severity = {
+    'RED': 3,
+    'YELLOW': 4
+    }

--- a/napalm_logs/config/junos.yml
+++ b/napalm_logs/config/junos.yml
@@ -109,6 +109,43 @@ messages:
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//state//prefixes//received: current
         bgp//neighbors//neighbor//{peer}//afi_safis//afi_safi//{table}//ipv6_{type}//prefix_limit//state//max_prefixes: limit
       static: {}
+  - error: SYSTEM_ALARM_FPC
+    tag: Alarm set
+    values:
+      component: (FPC \d)
+      color: (\w+)
+      reason: ([\w ]+)
+    replace:
+      color: color_to_severity
+    line: 'FPC color={color}, class=CHASSIS, reason={component} {reason}'
+    model: ietf-hardware
+    mapping:
+      variables:
+        hardware-state//component//{component}//name: component
+        hardware-state//component//{component}//state//alarm-state: color
+        hardware-state//component//{component}//state//alarm-reason: reason
+      static:
+        hardware-state//component//{component}//class: class
+# The following is a general catch all for system alarms, if you would like to
+# add more specif matches please do so above this comment
+  - error: SYSTEM_ALARM
+    tag: Alarm set
+    values:
+      component: (\w+)
+      color: (\w+)
+      class: (\w+)
+      reason: ([\w ]+)
+    replace:
+      color: color_to_severity
+    line: '{component} color={color}, class={class}, reason={reason}'
+    model: ietf-hardware
+    mapping:
+      variables:
+        hardware-state//component//{component}//name: component
+        hardware-state//component//{component}//class: class
+        hardware-state//component//{component}//state//alarm-state: color
+        hardware-state//component//{component}//state//alarm-reason: reason
+      static: {}
   - error: USER_ENTER_CONFIG_MODE
     tag: UI_DBASE_LOGIN_EVENT
     values:

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -307,12 +307,12 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                     self.pub_pipe.send(to_publish)
                 continue
             try:
-                oc_obj = self._emit(**kwargs)
+                yang_obj = self._emit(**kwargs)
             except Exception as err:
                 log.exception('Unexpected error when generating the OC object.', exc_info=True)
                 continue
             log.debug('Generated OC object:')
-            log.debug(oc_obj)
+            log.debug(yang_obj)
             error = kwargs.get('error')
             model_name = kwargs.get('oc_model')
             to_publish = {
@@ -320,9 +320,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                 'host': host,
                 'ip': address,
                 'timestamp': timestamp,
-                'open_config': oc_obj,
+                'yang_message': yang_obj,
                 'message_details': msg_dict,
-                'model_name': model_name,
+                'yang_model': model_name,
                 'os': self._name
             }
             log.debug('Queueing to be published:')


### PR DESCRIPTION
Currently I have only added this for junos. The log messages look as
follows:

```
<29>Jul  8 23:04:13  vmx01 alarmd[2449]: Alarm set: FPC
color=RED, class=CHASSIS, reason=FPC 0 Major Errors
```

We will output as follows:

```
{
  "message_details": {
    "processId": "2449",
    "hostPrefix": null,
    "pri": "29",
    "processName": "alarmd",
    "host": "vmx01",
    "tag": "Alarm set",
    "time": "23:04:13",
    "date": "Jul  8",
    "message": "FPC color=RED, class=CHASSIS, reason=FPC 0 Major Errors"
  },
  "open_config": {
    "hardware/classes/class/CHASSIS/componants/componant/FPC/state/color":
"RED",
    "hardware/classes/class/CHASSIS/componants/componant/FPC/state/reason":
"FPC 0 Major Errors"
  },
  "ip": "127.0.0.1",
  "error": "SYSTEM_ALARM",
  "host": "vmx01",
  "timestamp": "1499551453",
  "os": "junos",
  "model_name": "NO_MODEL"
}
```