### PR TITLE
Change eos BGP_PREFIX_THRESH_EXCEEDED error

### DIFF
--- a/napalm_logs/config/eos.yml
+++ b/napalm_logs/config/eos.yml
@@ -16,7 +16,7 @@ prefix:
 messages:
   # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
   # This may change if we are able to find a more well defined naming system.
-  - error: BGP_PREFIX_THRESH_EXCEEDED
+  - error: BGP_PREFIX_LIMIT_EXCEEDED
     tag: BGP-3-NOTIFICATION
     values:
       peer: (\d+\.\d+\.\d+\.\d+)


### PR DESCRIPTION
The error `BGP_PREFIX_THRESH_EXCEEDED` under `eos` should be
`BGP_PREFIX_LIMIT_EXCEEDED`. This is because the message listed only
occurs after the limit has been exceeded.