### PR TITLE
Add severity and facility to ooutput dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,43 +37,29 @@ Output object example
 
 ```json
 {
-  "ip": "127.0.0.1",
-  "host": "re0.edge01.bjm01",
-  "message_details": {
-    "processId": "2902",
-    "error": "BGP_PREFIX_THRESH_EXCEEDED",
-    "pri": "149",
-    "processName": "rpd",
-    "host": "re0.edge01.bjm01",
-    "time": "12:45:19",
-    "date": "Mar 30",
-    "message": "1.2.3.4 (External AS 15169): Configured maximum prefix-limit threshold(160) exceeded for inet-unicast nlri: 181 (instance master)"
-  },
-  "open_config": {
+  "yang_message": {
     "bgp": {
       "neighbors": {
         "neighbor": {
-          "1.2.3.4": {
-            "neighbor-address": "1.2.3.4",
+          "192.168.140.254": {
             "state": {
-              "peer-as": 15169
+              "peer_as": "65001"
             },
-            "afi-safis": {
-              "afi-safi": {
-                "inet": {
+            "afi_safis": {
+              "afi_safi": {
+                "inet4": {
                   "state": {
                     "prefixes": {
-                      "received": 181
+                      "received": "141"
                     }
                   },
-                  "ipv4-unicast": {
-                    "prefix-limit": {
+                  "ipv4_unicast": {
+                    "prefix_limit": {
                       "state": {
-                        "max-prefixes": 160
+                        "max_prefixes": "140"
                       }
                     }
-                  },
-                  "afi-safi-name": "inet"
+                  }
                 }
               }
             }
@@ -82,6 +68,24 @@ Output object example
       }
     }
   },
-  "timestamp": "1490877919"
+  "message_details": {
+    "processId": "2902",
+    "hostPrefix": null,
+    "pri": "149",
+    "processName": "rpd",
+    "host": "vmx01",
+    "tag": "BGP_PREFIX_THRESH_EXCEEDED",
+    "time": "14:03:12",
+    "date": "Jun 21",
+    "message": "192.168.140.254 (External AS 65001): Configured maximum prefix-limit threshold(140) exceeded for inet4-unicast nlri: 141 (instance master)"
+  },
+  "timestamp": 1498050192,
+  "facility": 18,
+  "ip": "127.0.0.1",
+  "host": "vmx01",
+  "yang_model": "openconfig_bgp",
+  "error": "BGP_PREFIX_THRESH_EXCEEDED",
+  "os": "junos",
+  "severity": 5
 }
 ```

--- a/README.rst
+++ b/README.rst
@@ -15,53 +15,58 @@ Will produce the following object:
 
 .. code-block:: json
 
-  {
-    "ip": "172.17.17.1",
-    "host": "edge01.bjm01",
-    "message_details": {
-      "processId": "15852",
-      "error": "BGP_PREFIX_THRESH_EXCEEDED",
-      "pri": "149",
-      "processName": "rpd",
-      "host": "edge01.bjm01",
-      "time": "12:45:19",
-      "date": "Mar 30",
-      "message": "1.2.3.4 (External AS 15169): Configured maximum prefix-limit threshold(160) exceeded for inet-unicast nlri: 181 (instance master)"
-    },
-    "open_config": {
-      "bgp": {
-        "neighbors": {
-          "neighbor": {
-            "1.2.3.4": {
-              "neighbor-address": "1.2.3.4",
-              "state": {
-                "peer-as": 15169
-              },
-              "afi-safis": {
-                "afi-safi": {
-                  "inet": {
-                    "state": {
-                      "prefixes": {
-                        "received": 181
-                      }
-                    },
-                    "ipv4-unicast": {
-                      "prefix-limit": {
-                        "state": {
-                          "max-prefixes": 160
-                        }
-                      }
-                    },
-                    "afi-safi-name": "inet"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "timestamp": "1490877919"
+	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "192.168.140.254": {
+				"state": {
+				  "peer_as": "65001"
+				},
+				"afi_safis": {
+				  "afi_safi": {
+					"inet4": {
+					  "state": {
+						"prefixes": {
+						  "received": "141"
+						}
+					  },
+					  "ipv4_unicast": {
+						"prefix_limit": {
+						  "state": {
+							"max_prefixes": "140"
+						  }
+						}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": "2902",
+		"hostPrefix": null,
+		"pri": "149",
+		"processName": "rpd",
+		"host": "vmx01",
+		"tag": "BGP_PREFIX_THRESH_EXCEEDED",
+		"time": "14:03:12",
+		"date": "Jun 21",
+		"message": "192.168.140.254 (External AS 65001): Configured maximum prefix-limit threshold(140) exceeded for inet4-unicast nlri: 141 (instance master)"
+	  },
+	  "timestamp": 1498050192,
+	  "facility": 18,
+	  "ip": "127.0.0.1",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_PREFIX_THRESH_EXCEEDED",
+	  "os": "junos",
+	  "severity": 5
+	}
   }
 
 

--- a/docs/messages/BGP_MD5_INCORRECT.rst
+++ b/docs/messages/BGP_MD5_INCORRECT.rst
@@ -14,37 +14,38 @@ Example:
 
 .. code-block:: json
 
-    {
-      "message_details": {
-        "processId": null,
-        "hostPrefix": null,
-        "pri": "4",
-        "processName": "kernel",
-        "host": "vmx01",
-        "tag": "tcp_auth_ok",
-        "time": "07:51:06",
-        "date": "Jun  9",
-        "message": "Packet from 192.168.140.254:56721 wrong MD5 digest"
-      },
-      "open_config": {
-        "bgp": {
-          "neighbors": {
-            "neighbor": {
-              "192.168.140.254": {
-                "state": {
-                  "session_state": "CONNECT"
-                },
-                "neighbor_address": "192.168.140.254"
-              }
-            }
-          }
-        }
-      },
-      "ip": "192.168.140.252",
-      "error": "BGP_MD5_INCORRECT",
-      "host": "vmx01",
-      "timestamp": 1496991066,
-      "os": "junos",
-      "model_name": "openconfig_bgp"
-    }
+	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "192.168.140.254": {
+				"state": {
+				  "session_state": "CONNECT"
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": null,
+		"hostPrefix": null,
+		"pri": "4",
+		"processName": "kernel",
+		"host": "vmx01",
+		"tag": "tcp_auth_ok",
+		"time": "18:19:48",
+		"date": "Jul 20",
+		"message": "Packet from 192.168.140.254:53921 wrong MD5 digest"
+	  },
+	  "timestamp": 1500571188,
+	  "facility": 0,
+	  "ip": "192.168.140.252",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_MD5_INCORRECT",
+	  "os": "junos",
+	  "severity": 4
+	}
 

--- a/docs/messages/BGP_PEER_NOT_CONFIGURED.rst
+++ b/docs/messages/BGP_PEER_NOT_CONFIGURED.rst
@@ -15,10 +15,24 @@ Example:
 .. code-block:: json
 
 	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "1.2.3.4": {
+				"state": {
+				  "session_state": "ACTIVE",
+				  "peer_as": "1234"
+				}
+			  }
+			}
+		  }
+		}
+	  },
 	  "message_details": {
 		"processId": "1848",
 		"hostPrefix": null,
-		"pri": "28",
+		"pri": "87",
 		"processName": "rpd",
 		"host": "vmx01",
 		"tag": "bgp_read_message",
@@ -26,26 +40,13 @@ Example:
 		"date": "Jul  5",
 		"message": "2764: NOTIFICATION received from 1.2.3.4 (External AS 1234): code 6 (Cease) subcode 5 (Connection Rejected)"
 	  },
-	  "open_config": {
-		"bgp": {
-		  "neighbors": {
-			"neighbor": {
-			  "1.2.3.4": {
-				"state": {
-				  "session_state": "ACTIVE",
-				  "peer_as": 1234
-				},
-				"neighbor_address": "1.2.3.4"
-			  }
-			}
-		  }
-		}
-	  },
-	  "ip": "127.0.0.1",
-	  "error": "BGP_PEER_NOT_CONFIGURED",
-	  "host": "vmx01",
 	  "timestamp": 1499230364,
+	  "facility": 10,
+	  "ip": "127.0.0.1",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_PEER_NOT_CONFIGURED",
 	  "os": "junos",
-	  "model_name": "openconfig_bgp"
+	  "severity": 7
 	}
 

--- a/docs/messages/BGP_PREFIX_LIMIT_EXCEEDED.rst
+++ b/docs/messages/BGP_PREFIX_LIMIT_EXCEEDED.rst
@@ -14,56 +14,56 @@ Example:
 
 .. code-block:: json
 
-    {
-      "message_details": {
-        "processId": "2942",
-        "hostPrefix": null,
-        "pri": "28",
-        "processName": "rpd",
-        "host": "vmx2",
-        "tag": "BGP_PREFIX_LIMIT_EXCEEDED",
-        "time": "13:35:25",
-        "date": "Jul  4",
-        "message": "10.0.0.31 (Internal AS 65001): Configured maximum prefix-limit(1) exceeded for inet-unicast nlri: 7 (instance master)"
-      },
-      "open_config": {
-        "bgp": {
-          "neighbors": {
-            "neighbor": {
-              "10.0.0.31": {
-                "state": {
-                  "peer_as": 65001
-                },
-                "afi_safis": {
-                  "afi_safi": {
-                    "inet": {
-                      "state": {
-                        "prefixes": {
-                          "received": 7
-                        }
-                      },
-                      "afi_safi_name": "inet",
-                      "ipv4_unicast": {
-                        "prefix_limit": {
-                          "state": {
-                            "max_prefixes": 1
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "neighbor_address": "10.0.0.31"
-              }
-            }
-          }
-        }
-      },
-      "ip": "130.211.119.212",
-      "error": "BGP_PREFIX_LIMIT_EXCEEDED",
-      "host": "vmx2",
-      "timestamp": 1499175325,
-      "os": "junos",
-      "model_name": "openconfig_bgp"
-    }
+	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "192.168.140.254": {
+				"state": {
+				  "peer_as": "65001"
+				},
+				"afi_safis": {
+				  "afi_safi": {
+					"inet4": {
+					  "state": {
+						"prefixes": {
+						  "received": "141"
+						}
+					  },
+					  "ipv4_unicast": {
+						"prefix_limit": {
+						  "state": {
+							"max_prefixes": "140"
+						  }
+						}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": "2902",
+		"hostPrefix": null,
+		"pri": "149",
+		"processName": "rpd",
+		"host": "vmx01",
+		"tag": "BGP_PREFIX_THRESH_EXCEEDED",
+		"time": "14:03:12",
+		"date": "Jun 21",
+		"message": "192.168.140.254 (External AS 65001): Configured maximum prefix-limit threshold(140) exceeded for inet4-unicast nlri: 141 (instance master)"
+	  },
+	  "timestamp": 1498050192,
+	  "facility": 18,
+	  "ip": "127.0.0.1",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_PREFIX_THRESH_EXCEEDED",
+	  "os": "junos",
+	  "severity": 5
+	}
 

--- a/docs/messages/BGP_PREFIX_THRESH_EXCEEDED.rst
+++ b/docs/messages/BGP_PREFIX_THRESH_EXCEEDED.rst
@@ -16,55 +16,56 @@ Example:
 
 .. code-block:: json
 
-    {
-      "message_details": {
-        "processId": "2942",
-        "hostPrefix": null,
-        "pri": "28",
-        "processName": "rpd",
-        "host": "vmx2",
-        "tag": "BGP_PREFIX_THRESH_EXCEEDED",
-        "time": "13:35:25",
-        "date": "Jul  4",
-        "message": "10.0.0.31 (Internal AS 65001): Configured maximum prefix-limit(1) exceeded for inet-unicast nlri: 7 (instance master)"
-      },
-      "open_config": {
-        "bgp": {
-          "neighbors": {
-            "neighbor": {
-              "10.0.0.31": {
-                "state": {
-                  "peer_as": 65001
-                },
-                "afi_safis": {
-                  "afi_safi": {
-                    "inet": {
-                      "state": {
-                        "prefixes": {
-                          "received": 7
-                        }
-                      },
-                      "afi_safi_name": "inet",
-                      "ipv4_unicast": {
-                        "prefix_limit": {
-                          "state": {
-                            "max_prefixes": 1
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "neighbor_address": "10.0.0.31"
-              }
-            }
-          }
-        }
-      },
-      "ip": "130.211.119.212",
-      "error": "BGP_PREFIX_THRESH_EXCEEDED",
-      "host": "vmx2",
-      "timestamp": 1499175325,
-      "os": "junos",
-      "model_name": "openconfig_bgp"
-    }
+	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "192.168.140.254": {
+				"state": {
+				  "peer_as": "65001"
+				},
+				"afi_safis": {
+				  "afi_safi": {
+					"inet": {
+					  "state": {
+						"prefixes": {
+						  "received": "28"
+						}
+					  },
+					  "ipv4_unicast": {
+						"prefix_limit": {
+						  "state": {
+							"max_prefixes": "3"
+						  }
+						}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": "2965",
+		"hostPrefix": null,
+		"pri": "28",
+		"processName": "rpd",
+		"host": "vmx01",
+		"tag": "BGP_PREFIX_LIMIT_EXCEEDED",
+		"time": "18:45:25",
+		"date": "Jul 20",
+		"message": "192.168.140.254 (External AS 65001): Configured maximum prefix-limit(3) exceeded for inet-unicast nlri: 28 (instance master)"
+	  },
+	  "timestamp": 1500572725,
+	  "facility": 3,
+	  "ip": "192.168.140.252",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_PREFIX_LIMIT_EXCEEDED",
+	  "os": "junos",
+	  "severity": 4
+	}
+

--- a/docs/messages/RAW.rst
+++ b/docs/messages/RAW.rst
@@ -41,5 +41,7 @@ Example:
     "timestamp": 1499682723,
     "os": "junos",
     "model_name": "raw",
-    "error": "RAW"
+    "error": "RAW",
+    "facility": 4,
+    "severity": 5
   }

--- a/docs/messages/SYSTEM_ALARM.rst
+++ b/docs/messages/SYSTEM_ALARM.rst
@@ -22,31 +22,33 @@ Example:
 		  "component": {
 			"FPC 0": {
 			  "state": {
-				"alarm-reason": "FPC 0 Major Errors",
+				"alarm-reason": "Major Errors",
 				"alarm-state": 3
 			  },
 			  "name": "FPC 0",
-			  "class": "CHASSIS"
+			  "class": "class"
 			}
 		  }
 		}
 	  },
 	  "message_details": {
-		"processId": "2449",
+		"processId": "2411",
 		"hostPrefix": null,
-		"pri": "29",
+		"pri": "28",
 		"processName": "alarmd",
 		"host": "vmx01",
 		"tag": "Alarm set",
-		"time": "23:04:13",
-		"date": "Jul  8",
+		"time": "13:13:16",
+		"date": "Jul 17",
 		"message": "FPC color=RED, class=CHASSIS, reason=FPC 0 Major Errors"
 	  },
-	  "timestamp": "1499551453",
+	  "timestamp": 1500293596,
+	  "facility": 3,
 	  "ip": "127.0.0.1",
 	  "host": "vmx01",
 	  "yang_model": "ietf-hardware",
-	  "error": "SYSTEM_ALARM",
-	  "os": "junos"
+	  "error": "SYSTEM_ALARM_FPC",
+	  "os": "junos",
+	  "severity": 4
 	}
 

--- a/docs/messages/UNKNOWN.rst
+++ b/docs/messages/UNKNOWN.rst
@@ -17,14 +17,15 @@ Example:
 
 .. code-block:: json
 
-  {
-    "message_details": {
-      "message": "<28>Jul 10 10:32:00 vmx1 inetd[2397]: /usr/sbin/sshd[89736]: exited, status 255"
-    },
-    "ip": "172.17.17.1",
-    "host": "unknown",
-    "timestamp": 1499682737,
-    "os": "unknown",
-    "model_name": "unknown",
-    "error": "UNKNOWN"
-  }
+	{
+	  "message_details": {
+		"message": "<28>Jul 10 10:32:00 vmx1 inetd[2397]: /usr/sbin/sshd[89736]: exited, status 255\n"
+	  },
+	  "timestamp": 1501685287,
+	  "ip": "127.0.0.1",
+	  "host": "unknown",
+	  "error": "UNKNOWN",
+	  "os": "unknown",
+	  "model_name": "unknown"
+	}
+

--- a/docs/messages/index.rst
+++ b/docs/messages/index.rst
@@ -14,59 +14,59 @@ For example, the following syslog message:
 
 .. code-block:: json
 
-    {
-      "message_details": {
-        "processId": "2942",
-        "hostPrefix": null,
-        "pri": "28",
-        "processName": "rpd",
-        "host": "vmx2",
-        "tag": "BGP_PREFIX_LIMIT_EXCEEDED",
-        "time": "13:35:25",
-        "date": "Jul  4",
-        "message": "10.0.0.31 (Internal AS 65001): Configured maximum prefix-limit(1) exceeded for inet-unicast nlri: 7 (instance master)"
-      },
-      "open_config": {
-        "bgp": {
-          "neighbors": {
-            "neighbor": {
-              "10.0.0.31": {
-                "state": {
-                  "peer_as": 65001
-                },
-                "afi_safis": {
-                  "afi_safi": {
-                    "inet": {
-                      "state": {
-                        "prefixes": {
-                          "received": 7
-                        }
-                      },
-                      "afi_safi_name": "inet",
-                      "ipv4_unicast": {
-                        "prefix_limit": {
-                          "state": {
-                            "max_prefixes": 1
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "neighbor_address": "10.0.0.31"
-              }
-            }
-          }
-        }
-      },
-      "ip": "130.211.119.212",
-      "error": "BGP_PREFIX_LIMIT_EXCEEDED",
-      "host": "vmx2",
-      "timestamp": 1499175325,
-      "os": "junos",
-      "model_name": "openconfig_bgp"
-    }
-
+	{
+	  "yang_message": {
+		"bgp": {
+		  "neighbors": {
+			"neighbor": {
+			  "192.168.140.254": {
+				"state": {
+				  "peer_as": "65001"
+				},
+				"afi_safis": {
+				  "afi_safi": {
+					"inet4": {
+					  "state": {
+						"prefixes": {
+						  "received": "141"
+						}
+					  },
+					  "ipv4_unicast": {
+						"prefix_limit": {
+						  "state": {
+							"max_prefixes": "140"
+						  }
+						}
+					  }
+					}
+				  }
+				}
+			  }
+			}
+		  }
+		}
+	  },
+	  "message_details": {
+		"processId": "2902",
+		"hostPrefix": null,
+		"pri": "149",
+		"processName": "rpd",
+		"host": "vmx01",
+		"tag": "BGP_PREFIX_THRESH_EXCEEDED",
+		"time": "14:03:12",
+		"date": "Jun 21",
+		"message": "192.168.140.254 (External AS 65001): Configured maximum prefix-limit threshold(140) exceeded for inet4-unicast nlri: 141 (instance master)"
+	  },
+	  "timestamp": 1498050192,
+	  "facility": 18,
+	  "ip": "127.0.0.1",
+	  "host": "vmx01",
+	  "yang_model": "openconfig_bgp",
+	  "error": "BGP_PREFIX_THRESH_EXCEEDED",
+	  "os": "junos",
+	  "severity": 5
+	}
+    
 Under this section, we present the possible error tags, together with their corresponding YANG model and examples.
 
 .. toctree::

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -237,6 +237,10 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             timestamp = self._format_time(msg_dict.get('time', ''),
                                           msg_dict.get('date', ''),
                                           prefix_id)
+            # The pri has to be an int as it is retrived using regex '\<(\d+)\>' in server.py
+            priority = int(msg_dict.get('pri', 0))
+            facility = priority / 8
+            severity = priority - (facility * 8)
             kwargs = self._parse(msg_dict)
             if not kwargs:
                 # Unable to identify what model to generate for the message in cause.
@@ -249,7 +253,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                         'message_details': msg_dict,
                         'os': self._name,
                         'error': 'RAW',
-                        'model_name': 'raw'
+                        'model_name': 'raw',
+                        'facility': facility,
+                        'severity': severity
                     }
                     log.debug('Queueing to be published:')
                     log.debug(to_publish)
@@ -276,7 +282,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                 'yang_message': yang_obj,
                 'message_details': msg_dict,
                 'yang_model': model_name,
-                'os': self._name
+                'os': self._name,
+                'facility': facility,
+                'severity': severity
             }
             log.debug('Queueing to be published:')
             log.debug(to_publish)


### PR DESCRIPTION
The priority is made up of facility * 8 + severity
(https://www.balabit.com/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/bsdsyslog-pri.html).
So to get the severity and facility from to priority you need to do:

```
facility = floor(priority / 8)
severity = priority - (facility * 8)
```