### PR TITLE
Add severity and facility on intial message parse

### DIFF
--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -237,10 +237,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             timestamp = self._format_time(msg_dict.get('time', ''),
                                           msg_dict.get('date', ''),
                                           prefix_id)
-            # The pri has to be an int as it is retrived using regex '\<(\d+)\>' in server.py
-            priority = int(msg_dict.get('pri', 0))
-            facility = priority / 8
-            severity = priority - (facility * 8)
+            facility = msg_dict.get('facility')
+            severity = msg_dict.get('severity')
+
             kwargs = self._parse(msg_dict)
             if not kwargs:
                 # Unable to identify what model to generate for the message in cause.

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -149,6 +149,11 @@ class NapalmLogsServerProc(NapalmLogsProc):
                 # Remove whitespace from the start or end of the message
                 ret['__prefix_id__'] = prefix_id
                 ret['message'] = ret['message'].strip()
+
+                # The pri has to be an int as it is retrived using regex '\<(\d+)\>'
+                if 'pri' in ret:
+                    ret['facility'] = int(ret['pri']) / 8
+                    ret['severity'] = int(ret['pri']) - (ret['facility'] * 8)
                 # TODO Should we stop searching and just return, or should we return all matches OS?
                 return dev_os, ret
             log.debug('No prefix matched under %s', dev_os)


### PR DESCRIPTION
I wanted to have the severity and facility outputted with the `send_raw`
option, so I have moved where we add them to earlier in the process.