### PR TITLE
Add time format for all OS

### DIFF
--- a/napalm_logs/config/iosxr/init.yml
+++ b/napalm_logs/config/iosxr/init.yml
@@ -4,7 +4,8 @@
 # Matching white space in `values`
 #
 prefixes:
-  - values:
+  - time_format: "%b %d %H:%M:%S"
+    values:
       messageId: (\d+)
       # On IOS-XR syslog messages do not contain the hostname by default, they
       # only provide the node-id which, e.g RP/0/RSP0/CPU0. To include the
@@ -13,10 +14,11 @@ prefixes:
       host: ([^ ]+ )?
       nodeId: ([^ ]+)
       date: (\w+ +\d+)
-      time: (\d\d:\d\d:\d\d\.\d\d\d)
+      time: (\d\d:\d\d:\d\d)
+      milliseconds: (\.\d\d\d)
       timeZone: \s?(\w\w\w)?
       processName: (\w+)
       processId: (\d+)
       tag: ([\w-]+)
-    line: '{messageId}: {host}{nodeId}:{date} {time}{timeZone}: {processName}[{processId}]: %{tag}'
+    line: '{messageId}: {host}{nodeId}:{date} {time}{milliseconds}{timeZone}: {processName}[{processId}]: %{tag}'
 

--- a/napalm_logs/config/nxos/__init__.py
+++ b/napalm_logs/config/nxos/__init__.py
@@ -22,6 +22,8 @@ _RGX_PARTS = OrderedDict(_RGX_PARTS)
 
 _RGX = '\<{0[pri]}\>{0[host]}: {0[date]} {0[time]} {0[timeZone]}: %{0[tag]}: {0[message]}'.format(_RGX_PARTS)
 
+_TIME_FORMAT = ('{date} {time} {timeZone}', '%Y %b %d %H:%M:%S %Z')
+
 
 def extract(msg):
-    return napalm_logs.utils.extract(_RGX, msg, _RGX_PARTS)
+    return napalm_logs.utils.extract(_RGX, msg, _RGX_PARTS, _TIME_FORMAT)

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -184,7 +184,7 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         if not time or not date or not time_format:
             return int(datetime.now().strftime('%s'))
         # Most syslog do not include the year, so we will add the current year if we are not supplied with one
-        if '%y' in date or '%Y' in date:
+        if '%y' in time_format or '%Y' in time_format:
             timestamp = datetime.strptime('{} {}'.format(date, time), time_format)
         else:
             year = datetime.now().year
@@ -234,9 +234,12 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             # From here on, we're running in a regular OS sub-process.
             host = msg_dict.get('host')
             prefix_id = msg_dict.pop('__prefix_id__')
-            timestamp = self._format_time(msg_dict.get('time', ''),
-                                          msg_dict.get('date', ''),
-                                          prefix_id)
+            if 'timestamp' in msg_dict:
+                timestamp = msg_dict['timestamp']
+            else:
+                timestamp = self._format_time(msg_dict.get('time', ''),
+                                              msg_dict.get('date', ''),
+                                              prefix_id)
             facility = msg_dict.get('facility')
             severity = msg_dict.get('severity')
 

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -14,6 +14,7 @@ import socket
 import logging
 import threading
 import collections
+from datetime import datetime
 
 # Import python stdlib
 import umsgpack
@@ -163,7 +164,7 @@ def unserialize(binary):
     return umsgpack.unpackb(binary)
 
 
-def extract(rgx, msg, mapping):
+def extract(rgx, msg, mapping, time_format=None):
     ret = {}
     log.debug('Matching regex "%s" on "%s"', rgx, msg)
     matched = re.search(rgx, msg, re.I)
@@ -178,6 +179,11 @@ def extract(rgx, msg, mapping):
             group_index += 1
         log.debug('Regex matched')
         log.debug(ret)
+    if time_format:
+        try:
+            ret['timestamp'] = int(datetime.strptime(time_format[0].format(**ret), time_format[1]).strftime('%s'))
+        except ValueError as error:
+            log.error('Unable to convert date and time into a timestamp: %s', error)
     return ret
 
 


### PR DESCRIPTION
I have added a `time_format` key to the perfix of all `yml` prefix
files.

For the py profiler prefixes I have added a new function called
`time_format` which will just return the time format. I am not sure if
this is the best way, but didn't want to just attach it to the regex
dict.