### PR TITLE
Symmetric listener

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -25,12 +25,12 @@ import nacl.encoding
 # Import napalm-logs pkgs
 import napalm_logs.utils
 import napalm_logs.config as CONFIG
-from napalm_logs.listener import get_listener
 # processes
 from napalm_logs.auth import NapalmLogsAuthProc
 from napalm_logs.device import NapalmLogsDeviceProc
 from napalm_logs.server import NapalmLogsServerProc
 from napalm_logs.publisher import NapalmLogsPublisherProc
+from napalm_logs.listener_proc import NapalmLogsListenerProc
 # exceptions
 from napalm_logs.exceptions import ConfigurationException
 
@@ -74,7 +74,7 @@ class NapalmLogs:
         '''
         self.address = address
         self.port = port
-        self.listener = listener
+        self.listener_type = listener
         self.publish_address = publish_address
         self.publish_port = publish_port
         self.auth_address = auth_address
@@ -426,7 +426,6 @@ class NapalmLogs:
                                   sgn_verify_hex,
                                   self.auth_address,
                                   self.auth_port)
-        auth.verify_cert()
         proc = Process(target=auth.start)
         proc.start()
         log.debug('Started auth process as %s with PID %s', proc._name, proc.pid)
@@ -438,8 +437,11 @@ class NapalmLogs:
         '''
         log.debug('Starting the listener process')
         # Get the correct listener class
-        listener_class = get_listener(self.listener)
-        listener = listener_class(self.address, self.port, pipe, **self.listener_opts)
+        listener = NapalmLogsListenerProc(self.address,
+                                          self.port,
+                                          self.listener_type,
+                                          pipe,
+                                          listener_opts=self.listener_opts)
         proc = Process(target=listener.start)
         proc.start()
         log.debug('Started listener process as %s with PID %s', proc._name, proc.pid)

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -14,6 +14,7 @@ CONFIG_FILE = os.path.join(ROOT_DIR, 'etc', 'napalm', 'logs')
 ADDRESS = '0.0.0.0'
 PORT = 514
 LISTENER = 'udp'
+MAX_TCP_CLIENTS = 5
 PUBLISH_ADDRESS = '0.0.0.0'
 PUBLISH_PORT = 49017
 AUTH_ADDRESS = '0.0.0.0'

--- a/napalm_logs/listener/base.py
+++ b/napalm_logs/listener/base.py
@@ -2,10 +2,9 @@
 '''
 napalm-logs listener base.
 '''
-from napalm_logs.proc import NapalmLogsProc
 
 
-class ListenerBase(NapalmLogsProc):
+class ListenerBase:
     '''
     The base class for the listener.
     '''
@@ -13,10 +12,20 @@ class ListenerBase(NapalmLogsProc):
         pass
 
     def start(self):
+        '''
+        Starts the listener.
+        '''
         pass
 
-    def publish(self, obj):
+    def receive(self):
+        '''
+        Return an object read from the source,
+        and the location identification object.
+        '''
         pass
 
     def stop(self):
+        '''
+        Shuts down the listener.
+        '''
         pass

--- a/napalm_logs/listener/tcp.py
+++ b/napalm_logs/listener/tcp.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import pythond stdlib
-import os
+import Queue
 import time
-import signal
+import random
 import socket
 import logging
 import threading
@@ -18,10 +18,11 @@ import threading
 # Import napalm-logs pkgs
 from napalm_logs.config import TIMEOUT
 from napalm_logs.config import BUFFER_SIZE
+from napalm_logs.config import MAX_TCP_CLIENTS
 from napalm_logs.listener.base import ListenerBase
 # exceptions
+from napalm_logs.exceptions import BindException
 from napalm_logs.exceptions import ListenerException
-from napalm_logs.exceptions import NapalmLogsExit
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class TCPListener(ListenerBase):
     '''
     TCP syslog listener class
     '''
-    def __init__(self, address, port, pipe, **kwargs):
+    def __init__(self, address, port, **kwargs):
         if kwargs.get('address'):
             self.address = kwargs['address']
         else:
@@ -39,72 +40,96 @@ class TCPListener(ListenerBase):
             self.port = kwargs['port']
         else:
             self.port = port
-        self.pipe = pipe
-        self.__up = False
+        self.buffer_size = kwargs.get('buffer_size', BUFFER_SIZE)
+        self.socket_timeout = kwargs.get('socket_timeout', TIMEOUT)
+        self.max_clients = kwargs.get('max_clients', MAX_TCP_CLIENTS)
+        self.buffer = Queue.Queue()
 
-    def _exit_gracefully(self, signum, _):
-        log.debug('Caught signal in listener process')
-        self.stop()
-
-    def _open_socket(self, socket_type):
+    def _client_connection(self, conn, addr):
         '''
-        Open the socket to listen for messages on
+        Handle the connecition with one client.
         '''
-        if ':' in self.address:
-            skt = socket.socket(socket.AF_INET6, socket_type)
-        else:
-            skt = socket.socket(socket.AF_INET, socket_type)
-        return skt
+        log.debug('Established connection with %s:%d', addr[0], addr[1])
+        conn.settimeout(self.socket_timeout)
+        try:
+            while self.__up:
+                msg = conn.recv(self.buffer_size)
+                if not msg:
+                    # log.debug('Received empty message from %s', addr)
+                    # disabled ^ as it was too noisy
+                    continue
+                log.debug('[%s] Received %s from %s. Adding in the queue', time.time(), msg, addr)
+                self.buffer.put((msg, '{}:{}'.format(addr[0], addr[1])))
+        except socket.timeout:
+            if not self.__up:
+                return
+            log.debug('Connection %s:%d timed out', addr[1], addr[0])
+            raise ListenerException('Connection %s:%d timed out' % addr)
+        finally:
+            log.debug('Closing connection with %s', addr)
+            conn.close()
 
-    def _tcp_connection(self, conn, addr):
-        log.debug('Established connection with %s', addr)
-        conn.settimeout(TIMEOUT)
-        while True:
+    def _serve_clients(self):
+        '''
+        Accept cients and serve, one separate thread per client.
+        '''
+        self.__up = True
+        while self.__up:
+            log.debug('Waiting for a client to connect')
             try:
-                msg = conn.recv(BUFFER_SIZE)
-            except socket.timeout:
-                log.debug('Connection %s timed out', addr)
-                return
-            if not msg:
-                log.info('Received empty message from %s', addr)
-                return
-            log.debug('[%s] Received %s from %s. Adding in the queue', msg, addr, time.time())
-            self.pipe.send((msg, addr))
-        log.debug('Closing connection with %s', addr)
-        conn.close()
+                conn, addr = self.skt.accept()
+                log.debug('Received connection from %s:%d', addr[0], addr[1])
+            except socket.error as error:
+                if not self.__up:
+                    return
+                msg = 'Received listener socket error: {}'.format(error)
+                log.error(msg, exc_info=True)
+                raise ListenerException(msg)
+            client_thread = threading.Thread(target=self._client_connection, args=(conn, addr,))
+            client_thread.start()
 
     def start(self):
         '''
-        Start listening for messages
+        Start listening for messages.
         '''
-        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
-        thread.start()
-        signal.signal(signal.SIGTERM, self._exit_gracefully)
-        self.__up = True
-        self.skt = self._open_socket(socket.SOCK_STREAM)
+        log.debug('Creating the TCP server')
+        if ':' in self.address:
+            self.skt = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        else:
+            self.skt = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.skt.bind((self.address, int(self.port)))
         except socket.error as msg:
             error_string = 'Unable to bind to port {} on {}: {}'.format(self.port, self.address, msg)
             log.error(error_string, exc_info=True)
-            raise ListenerException(error_string)
+            raise BindException(error_string)
+        log.debug('Accepting max %d parallel connections', self.max_clients)
+        self.skt.listen(self.max_clients)
+        self.thread_serve = threading.Thread(target=self._serve_clients)
+        self.thread_serve.start()
 
-        while self.__up:
-            self.skt.listen(1)
-            try:
-                conn, addr = self.skt.accept()
-            except socket.error as error:
-                if self.__up is False:
-                    return
-                else:
-                    msg = 'Received listener socket error: {}'.format(error)
-                    log.error(msg, exc_info=True)
-                    raise NapalmLogsExit(msg)
-            thread = threading.Thread(target=self._tcp_connection, args=(conn, addr,))
-            thread.start()
+    def receive(self):
+        '''
+        Return one message dequeued from the listen buffer.
+        '''
+        while self.buffer.empty() and self.__up:
+            # This sequence is skipped when the buffer is not empty.
+            sleep_ms = random.randint(0, 1000)
+            # log.debug('The message queue is empty, waiting %d miliseconds', sleep_ms)
+            # disabled ^ as it was too noisy
+            time.sleep(sleep_ms / 1000.0)
+        if not self.buffer.empty():
+            return self.buffer.get(block=False)
+        return '', ''
 
     def stop(self):
-        log.info('Stopping listener process')
+        '''
+        Closing the socket.
+        '''
+        log.info('Stopping the TCP listener')
         self.__up = False
+        try:
+            self.skt.shutdown(socket.SHUT_RDWR)
+        except socket.error:
+            log.error('The following error may not be critical:', exc_info=True)
         self.skt.close()
-        self.pipe.close()

--- a/napalm_logs/listener/tcp.py
+++ b/napalm_logs/listener/tcp.py
@@ -6,7 +6,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import pythond stdlib
-import Queue
+try:
+    import Queue as queue
+except ImportError
+    import queue
 import time
 import random
 import socket
@@ -43,7 +46,7 @@ class TCPListener(ListenerBase):
         self.buffer_size = kwargs.get('buffer_size', BUFFER_SIZE)
         self.socket_timeout = kwargs.get('socket_timeout', TIMEOUT)
         self.max_clients = kwargs.get('max_clients', MAX_TCP_CLIENTS)
-        self.buffer = Queue.Queue()
+        self.buffer = queue.Queue()
 
     def _client_connection(self, conn, addr):
         '''

--- a/napalm_logs/listener/tcp.py
+++ b/napalm_logs/listener/tcp.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 # Import pythond stdlib
 try:
     import Queue as queue
-except ImportError
+except ImportError:
     import queue
 import time
 import random

--- a/napalm_logs/listener/udp.py
+++ b/napalm_logs/listener/udp.py
@@ -6,12 +6,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import pythond stdlib
-import os
 import time
-import signal
 import socket
 import logging
-import threading
 
 # Import third party libs
 
@@ -20,16 +17,15 @@ from napalm_logs.config import BUFFER_SIZE
 from napalm_logs.listener.base import ListenerBase
 # exceptions
 from napalm_logs.exceptions import ListenerException
-from napalm_logs.exceptions import NapalmLogsExit
 
 log = logging.getLogger(__name__)
 
 
 class UDPListener(ListenerBase):
     '''
-    UDP syslog listener class
+    UDP syslog listener class.
     '''
-    def __init__(self, address, port, pipe, **kwargs):
+    def __init__(self, address, port, **kwargs):
         if kwargs.get('address'):
             self.address = kwargs['address']
         else:
@@ -38,32 +34,15 @@ class UDPListener(ListenerBase):
             self.port = kwargs['port']
         else:
             self.port = port
-        self.pipe = pipe
-        self.__up = False
-
-    def _exit_gracefully(self, signum, _):
-        log.debug('Caught signal in listener process')
-        self.stop()
-
-    def _open_socket(self, socket_type):
-        '''
-        Open the socket to listen for messages on
-        '''
-        if ':' in self.address:
-            skt = socket.socket(socket.AF_INET6, socket_type)
-        else:
-            skt = socket.socket(socket.AF_INET, socket_type)
-        return skt
 
     def start(self):
         '''
-        Start listening for messages
+        Create the UDP listener socket.
         '''
-        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
-        thread.start()
-        signal.signal(signal.SIGTERM, self._exit_gracefully)
-        self.__up = True
-        self.skt = self._open_socket(socket.SOCK_DGRAM)
+        if ':' in self.address:
+            self.skt = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        else:
+            self.skt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
             self.skt.bind((self.address, int(self.port)))
         except socket.error as msg:
@@ -71,22 +50,21 @@ class UDPListener(ListenerBase):
             log.error(error_string, exc_info=True)
             raise ListenerException(error_string)
 
-        while self.__up:
-            try:
-                msg, addr = self.skt.recvfrom(BUFFER_SIZE)
-                msg.decode('utf-8')
-            except socket.error as error:
-                if self.__up is False:
-                    return
-                else:
-                    msg = 'Received listener socket error: {}'.format(error)
-                    log.error(msg, exc_info=True)
-                    raise NapalmLogsExit(msg)
-            log.debug('[%s] Received %s from %s. Adding in the queue', msg, addr, time.time())
-            self.pipe.send((msg, addr[0]))
+    def receive(self):
+        '''
+        Return the message received and the address.
+        '''
+        try:
+            msg, addr = self.skt.recvfrom(BUFFER_SIZE)
+        except socket.error as error:
+            log.error('Received listener socket error: %s', error, exc_info=True)
+            raise ListenerException(error)
+        log.debug('[%s] Received %s from %s', msg, addr, time.time())
+        return msg, addr[0]
 
     def stop(self):
-        log.info('Stopping listener process')
-        self.__up = False
+        '''
+        Shut down the UDP listener.
+        '''
+        log.info('Stopping the UDP listener')
         self.skt.close()
-        self.pipe.close()

--- a/napalm_logs/listener/udp.py
+++ b/napalm_logs/listener/udp.py
@@ -16,6 +16,7 @@ import logging
 from napalm_logs.config import BUFFER_SIZE
 from napalm_logs.listener.base import ListenerBase
 # exceptions
+from napalm_logs.exceptions import BindException
 from napalm_logs.exceptions import ListenerException
 
 log = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class UDPListener(ListenerBase):
         except socket.error as msg:
             error_string = 'Unable to bind to port {} on {}: {}'.format(self.port, self.address, msg)
             log.error(error_string, exc_info=True)
-            raise ListenerException(error_string)
+            raise BindException(error_string)
 
     def receive(self):
         '''

--- a/napalm_logs/listener/udp.py
+++ b/napalm_logs/listener/udp.py
@@ -35,6 +35,7 @@ class UDPListener(ListenerBase):
             self.port = kwargs['port']
         else:
             self.port = port
+        self.buffer_size = kwargs.get('buffer_size', BUFFER_SIZE)
 
     def start(self):
         '''
@@ -56,7 +57,7 @@ class UDPListener(ListenerBase):
         Return the message received and the address.
         '''
         try:
-            msg, addr = self.skt.recvfrom(BUFFER_SIZE)
+            msg, addr = self.skt.recvfrom(self.buffer_size)
         except socket.error as error:
             log.error('Received listener socket error: %s', error, exc_info=True)
             raise ListenerException(error)

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -37,7 +37,7 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         self.listener_opts = {} or listener_opts
 
     def _exit_gracefully(self, signum, _):
-        log.debug('Caught signal in publisher process')
+        log.debug('Caught signal in the listener process')
         self.stop()
 
     def _setup_listener(self):
@@ -69,9 +69,12 @@ class NapalmLogsListenerProc(NapalmLogsProc):
                 # Exit on listener exception.
                 raise NapalmLogsExit(lerr)
             log.debug('Received %s from %s. Queueing to the server.', log_message, log_source)
+            if not log_message:
+                log.info('Empty message received from %s. Not queueing to the server.', log_source)
+                continue
             self.pipe.send((log_message, log_source))
 
     def stop(self):
-        log.info('Stopping listener process')
+        log.info('Stopping the listener process')
         self.__up = False
         self.listener.stop()

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+'''
+Listener worker process
+'''
+from __future__ import absolute_import
+
+# Import pythond stdlib
+import os
+import signal
+import logging
+import threading
+
+# Import napalm-logs pkgs
+from napalm_logs.proc import NapalmLogsProc
+from napalm_logs.listener import get_listener
+
+log = logging.getLogger(__name__)
+
+
+class NapalmLogsListenerProc(NapalmLogsProc):
+    '''
+    publisher sub-process class.
+    '''
+    def __init__(self,
+                 address,
+                 port,
+                 listener_type,
+                 pipe,
+                 listener_opts=None):
+        self.__up = False
+        self.address = address
+        self.port = port
+        self.pipe = pipe
+        self._listener_type = listener_type
+        self.listener_opts = {} or listener_opts
+
+    def _exit_gracefully(self, signum, _):
+        log.debug('Caught signal in publisher process')
+        self.stop()
+
+    def _setup_listener(self):
+        '''
+        Setup the transport.
+        '''
+        listener_class = get_listener(self._listener_type)
+        self.listener = listener_class(self.address,
+                                       self.port,
+                                       **self.listener_opts)
+
+    def start(self):
+        '''
+        Listen to messages and publish them.
+        '''
+        # self._setup_ipc()
+        log.debug('Using the %s listener', self._listener_type)
+        self._setup_listener()
+        # Start suicide polling thread
+        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
+        thread.start()
+        signal.signal(signal.SIGTERM, self._exit_gracefully)
+        self.listener.start()
+        self.__up = True
+        while self.__up:
+            log_message, log_source = self.listener.receive()
+            log.debug('Received %s from %s. Queueing to the server.', log_message, log_source)
+            self.pipe.send((log_message, log_source))
+
+    def stop(self):
+        log.info('Stopping listener process')
+        self.__up = False
+        self.listener.stop()

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -111,7 +111,6 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
                     msg = 'Received IOError on publisher pipe: {}'.format(error)
                     log.error(msg, exc_info=True)
                     raise NapalmLogsExit(msg)
-
             log.debug('Publishing the OC object (serialised)')
             if not self.disable_security:
                 bin_obj = self._prepare(obj)

--- a/napalm_logs/transport/base.py
+++ b/napalm_logs/transport/base.py
@@ -8,7 +8,7 @@ class TransportBase:
     '''
     The base class for the transport.
     '''
-    def __init__(self, addr, port, **kwargs):
+    def __init__(self, address, port, **kwargs):
         pass
 
     def start(self):


### PR DESCRIPTION
Treating the listener subsystem symmetrically:

- no need to send a custom Pipe in the `__init__`
- generic listener process starter in the engine base, similar to the publisher side
- smaller listener classes, having only the core without any other pipes or other details strongly related to napalm-logs, they having tree main methods:
  - `start`: startup the listener
  - `receive`: get one message
  - `stop`: shutdown the listener
  e.g.: the class for the UDP is as simple as that now: https://github.com/napalm-automation/napalm-logs/blob/58c09c38f87d5009c9f018178436290707d52ea8/napalm_logs/listener/udp.py, which simplifies the process to add a new listener class.