### PR TITLE
Change replace function to use |

### DIFF
--- a/docs/developers/device_profiles.rst
+++ b/docs/developers/device_profiles.rst
@@ -144,14 +144,11 @@ Here is an example message:
         tag: SNMP_TRAP_LINK_DOWN
         values:
           snmpID: (\d+)
-          adminStatusString: (\w+)
+          adminStatusString|uppercase: (\w+)
           adminStatusValue: (\d)
-          operStatusString: (\w+)
+          operStatusString|uppercase: (\w+)
           operStatusValue: (\d)
           interface: ([\w\-\/]+)
-        replace:
-          adminStatusString: uppercase
-          operStatusString: uppercase
         line: 'ifIndex {snmpID}, ifAdminStatus {adminStatusString}({adminStatusValue}), ifOperStatus {operStatusString}({operStatusValue}), ifName {interface}'
         model: openconfig_interfaces
         mapping:
@@ -195,15 +192,10 @@ This is the same as ``line`` above.
 ----------
 
 This is the same as ``values`` above, other than the fact they can be used in
-``mapping`` (this will be covered under ``mapping``).
+``mapping`` (this will be covered under ``mapping``). You can manipulate these
+values using replace functions found in napalm_logs.utils.Replace i.e
+``adminStatusString|uppercase``.
 
-``replace``
------------
-
-This is used to manipulate a variable taken from the message via a lambda
-function which are defined under ``napalm_logs/config/__init__.py``. The reason
-for this is that sometimes the YANG model expects variables in a certain
-format, i.e uppercase rather than lowercase.
 
 ``model``
 ---------

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -262,7 +262,6 @@ class NapalmLogs:
                                 '__python_mod__': filepath,  # Will be used for debugging
                                 'line': '',
                                 'model': model,
-                                'replace': {},
                                 'values': {},
                                 'mapping': {'variables': {}, 'static': {}}
                             })

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -78,7 +78,6 @@ VALID_CONFIG = {
             'error': six.string_type,
             'tag': six.string_type,
             'values': dict,
-            'replace': dict,
             'line': six.string_type,
             'model': six.string_type,
             'mapping': {
@@ -123,16 +122,3 @@ MAGIC_REQ = b'INIT'
 AUTH_CIPHER = 'ECDHE-RSA-AES256-GCM-SHA384'
 
 OPEN_CONFIG_NO_MODEL = 'NO_MODEL'
-
-# replacement lambdas
-REPLACEMENTS = {
-    'uppercase': lambda var: var.upper(),
-    'lowercase': lambda var: var.lower(),
-    'color_to_severity': lambda var: _COLOR_TO_severity.get(var, 0)
-}
-
-# For use with replacement lamdas
-_COLOR_TO_severity = {
-    'RED': 3,
-    'YELLOW': 4
-    }

--- a/napalm_logs/config/eos/BGP_PREFIX_LIMIT_EXCEEDED.yml
+++ b/napalm_logs/config/eos/BGP_PREFIX_LIMIT_EXCEEDED.yml
@@ -6,7 +6,6 @@ messages:
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       asn: (\d+)
-    replace: {}
     line: 'received from neighbor {peer} (AS {asn}) 6/1 (Cease/maximum number of prefixes reached) 0 bytes'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED.yml
+++ b/napalm_logs/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED.yml
@@ -5,9 +5,8 @@ messages:
     tag: ROUTING-BGP-5-MAXPFX
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
-      current: (\d+)
-      limit: (\d+)
-    replace: {}
+      current|int: (\d+)
+      limit|int: (\d+)
     line: 'No. of IPv4 Unicast prefixes received from {peer} has reached {current}, max {limit}'
     model: openconfig_bgp
     mapping:
@@ -19,9 +18,8 @@ messages:
     tag: ROUTING-BGP-5-MAXPFX
     values:
       peer: ([\w\d:]+)
-      current: (\d+)
-      limit: (\d+)
-    replace: {}
+      current|int: (\d+)
+      limit|int: (\d+)
     line: 'No. of IPv6 Unicast prefixes received from {peer} has reached {current}, max {limit}'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos/BGP_MD5_INCORRECT.yml
+++ b/napalm_logs/config/junos/BGP_MD5_INCORRECT.yml
@@ -6,7 +6,6 @@ messages:
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       port: (\d+)
-    replace: {}
     line: 'Packet from {peer}:{port} wrong MD5 digest'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos/BGP_PEER_NOT_CONFIGURED.yml
+++ b/napalm_logs/config/junos/BGP_PEER_NOT_CONFIGURED.yml
@@ -7,7 +7,6 @@ messages:
       peer: ([\w\d:\.]+)
       asn: (\d+)
       number: (\d+)
-    replace: {}
     line: '{number}: NOTIFICATION received from {peer} (External AS {asn}): code 6 (Cease) subcode 5 (Connection Rejected)'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos/BGP_PREFIX_LIMIT_EXCEEDED.yml
+++ b/napalm_logs/config/junos/BGP_PREFIX_LIMIT_EXCEEDED.yml
@@ -6,12 +6,11 @@ messages:
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       asn: (\d+)
-      limit: (\d+)
-      current: (\d+)
+      limit|int: (\d+)
+      current|int: (\d+)
       table: (\w+)
       type: (\w+)
       peeringType: (\w+)
-    replace: {}
     line: '{peer} ({peeringType} AS {asn}): Configured maximum prefix-limit({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:
@@ -25,12 +24,11 @@ messages:
     values:
       peer: ([\w\d:]+)
       asn: (\d+)
-      limit: (\d+)
-      current: (\d+)
+      limit|int: (\d+)
+      current|int: (\d+)
       table: (\w+)
       type: (\w+)
       peeringType: (\w+)
-    replace: {}
     line: '{peer} ({peeringType} AS {asn}): Configured maximum prefix-limit({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos/BGP_PREFIX_THRESH_EXCEEDED.yml
+++ b/napalm_logs/config/junos/BGP_PREFIX_THRESH_EXCEEDED.yml
@@ -6,12 +6,11 @@ messages:
     values:
       peer: (\d+\.\d+\.\d+\.\d+)
       asn: (\d+)
-      limit: (\d+)
-      current: (\d+)
+      limit|int: (\d+)
+      current|int: (\d+)
       table: (\w+)
       type: (\w+)
       peeringType: (\w+)
-    replace: {}
     line: '{peer} ({peeringType} AS {asn}): Configured maximum prefix-limit threshold({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:
@@ -25,12 +24,11 @@ messages:
     values:
       peer: ([\w\d:]+)
       asn: (\d+)
-      limit: (\d+)
-      current: (\d+)
+      limit|int: (\d+)
+      current|int: (\d+)
       table: (\w+)
       type: (\w+)
       peeringType: (\w+)
-    replace: {}
     line: '{peer} ({peeringType} AS {asn}): Configured maximum prefix-limit threshold({limit}) exceeded for {table}-{type} nlri: {current} (instance master)'
     model: openconfig_bgp
     mapping:

--- a/napalm_logs/config/junos/INTERFACE_DOWN.yml
+++ b/napalm_logs/config/junos/INTERFACE_DOWN.yml
@@ -5,14 +5,11 @@ messages:
     tag: SNMP_TRAP_LINK_DOWN
     values:
       snmpID: (\d+)
-      adminStatusString: (\w+)
+      adminStatusString|upper: (\w+)
       adminStatusValue: (\d)
-      operStatusString: (\w+)
+      operStatusString|upper: (\w+)
       operStatusValue: (\d)
       interface: ([\w\-\/]+)
-    replace:
-      adminStatusString: uppercase
-      operStatusString: uppercase
     line: 'ifIndex {snmpID}, ifAdminStatus {adminStatusString}({adminStatusValue}), ifOperStatus {operStatusString}({operStatusValue}), ifName {interface}'
     model: openconfig_interfaces
     mapping:

--- a/napalm_logs/config/junos/SYSTEM_ALARM.yml
+++ b/napalm_logs/config/junos/SYSTEM_ALARM.yml
@@ -5,10 +5,8 @@ messages:
     tag: Alarm set
     values:
       component: (FPC \d)
-      color: (\w+)
+      color|color_to_severity: (\w+)
       reason: ([\w ]+)
-    replace:
-      color: color_to_severity
     line: 'FPC color={color}, class=CHASSIS, reason={component} {reason}'
     model: ietf-hardware
     mapping:
@@ -24,11 +22,9 @@ messages:
     tag: Alarm set
     values:
       component: (\w+)
-      color: (\w+)
+      color|color_to_severity: (\w+)
       class: (\w+)
       reason: ([\w ]+)
-    replace:
-      color: color_to_severity
     line: '{component} color={color}, class={class}, reason={reason}'
     model: ietf-hardware
     mapping:

--- a/napalm_logs/config/junos/USER_ENTER_CONFIG_MODE.yml
+++ b/napalm_logs/config/junos/USER_ENTER_CONFIG_MODE.yml
@@ -5,7 +5,6 @@ messages:
     tag: UI_DBASE_LOGIN_EVENT
     values:
       user: (\w+)
-    replace: {}
     line: "User '{user}' entering configuration mode"
     model: NO_MODEL
     mapping:

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -14,6 +14,7 @@ import socket
 import logging
 import threading
 import collections
+from pydoc import locate
 from datetime import datetime
 
 # Import python stdlib
@@ -172,6 +173,31 @@ class ClientAuth:
         '''
         self.__up = False
         self.ssl_skt.close()
+
+
+def cast(var, function):
+    # If the function is a build in function
+    if locate(function) and hasattr(locate(function), '__call__'):
+        try:
+            return locate(function)(var)
+        except ValueError:
+            log.error('Unable to use function %s on value %s', function, var, exc_info=True)
+    # If the function is str function
+    if hasattr(str, function) and\
+            hasattr(getattr(str, function), '__call__'):
+        return getattr(str, function)(var)
+    glob = globals()
+    # If the function is defined in this module
+    if function in glob and hasattr(glob[function], '__call__'):
+        return glob[function](var)
+    # If none of the above, just return the original var
+    return var
+
+
+def color_to_severity(var):
+    colour_dict = {'RED': 3,
+                   'YELLOW': 4}
+    return colour_dict.get(var, var)
 
 
 def unserialize(binary):

--- a/tests/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED/default_v4/yang.json
+++ b/tests/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED/default_v4/yang.json
@@ -9,13 +9,13 @@
                 "inet": {
                   "state": {
                     "prefixes": {
-                      "received": "94106"
+                      "received": 94106
                     }
                   },
                   "ipv4_unicast": {
                     "prefix_limit": {
                       "state": {
-                        "max_prefixes": "125000"
+                        "max_prefixes": 125000
                       }
                     }
                   }

--- a/tests/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED/default_v6/yang.json
+++ b/tests/config/iosxr/BGP_PREFIX_THRESH_EXCEEDED/default_v6/yang.json
@@ -10,13 +10,13 @@
                   "ipv6_unicast": {
                     "prefix_limit": {
                       "state": {
-                        "max_prefixes": "125000"
+                        "max_prefixes": 125000
                       }
                     }
                   },
                   "state": {
                     "prefixes": {
-                      "received": "94106"
+                      "received": 94106
                     }
                   }
                 }

--- a/tests/config/junos/BGP_PREFIX_LIMIT_EXCEEDED/default/yang.json
+++ b/tests/config/junos/BGP_PREFIX_LIMIT_EXCEEDED/default/yang.json
@@ -12,13 +12,13 @@
                 "inet": {
                   "state": {
                     "prefixes": {
-                      "received": "28"
+                      "received": 28
                     }
                   },
                   "ipv4_unicast": {
                     "prefix_limit": {
                       "state": {
-                        "max_prefixes": "27"
+                        "max_prefixes": 27
                       }
                     }
                   }

--- a/tests/config/junos/BGP_PREFIX_THRESH_EXCEEDED/default/yang.json
+++ b/tests/config/junos/BGP_PREFIX_THRESH_EXCEEDED/default/yang.json
@@ -12,13 +12,13 @@
                 "inet4": {
                   "state": {
                     "prefixes": {
-                      "received": "141"
+                      "received": 141
                     }
                   },
                   "ipv4_unicast": {
                     "prefix_limit": {
                       "state": {
-                        "max_prefixes": "140"
+                        "max_prefixes": 140
                       }
                     }
                   }


### PR DESCRIPTION
Currently we use a the `replace` dict in the config to alter variables.
This commit changes it so we use a `|` much like in yaml.