### PR TITLE
Revisited the internal pipeline

### DIFF
--- a/docs/options/index.rst
+++ b/docs/options/index.rst
@@ -174,6 +174,36 @@ Configuration file example:
 
   extension_config_path: /home/admin/napalm-logs/
 
+.. _configuration-hwm:
+
+``hwm``: 1000
+-------------
+
+.. versionadded:: 0.3.0
+
+This option controls the ZeroMQ high water mark (the hard limit on the maximum
+number of outstanding messages ZeromMQ shall queue in memory).
+If this limit has been reached the internal sockets enter an exceptional state,
+and ZeroMQ blocks the reception of further messages.
+This option can be used to tune the performances of the napalm-logs, in terms of
+total messages processed. While the default limit should be generally
+enough, in environments with extremely high density of syslog messages to be
+processed, it is recommended to increase this value. Keep in mind that a higher
+queue implies higher memory consumption.
+For maximum capacity, this option can be set to ``0``, i.e., inifinite queue.
+
+CLI usage example:
+
+.. code-block:: bash
+
+  $ napalm-logs --hwm 0
+
+Configuration file example:
+
+.. code-block:: yaml
+
+  hwm: 0
+
 .. _configuration-options-keyfile:
 
 ``keyfile``

--- a/napalm_logs/auth.py
+++ b/napalm_logs/auth.py
@@ -55,12 +55,14 @@ class NapalmLogsAuthProc(NapalmLogsProc):
         | <------------ ACK ----------- |
     '''
     def __init__(self,
+                 opts,
                  certificate,
                  keyfile,
                  private_key,
                  signature_hex,
                  auth_address=AUTH_ADDRESS,
                  auth_port=AUTH_PORT):
+        self.opts = opts
         self.certificate = certificate
         self.keyfile = keyfile
         self.__key = private_key

--- a/napalm_logs/auth.py
+++ b/napalm_logs/auth.py
@@ -55,7 +55,6 @@ class NapalmLogsAuthProc(NapalmLogsProc):
         | <------------ ACK ----------- |
     '''
     def __init__(self,
-                 opts,
                  certificate,
                  keyfile,
                  private_key,

--- a/napalm_logs/auth.py
+++ b/napalm_logs/auth.py
@@ -61,7 +61,6 @@ class NapalmLogsAuthProc(NapalmLogsProc):
                  signature_hex,
                  auth_address=AUTH_ADDRESS,
                  auth_port=AUTH_PORT):
-        self.opts = opts
         self.certificate = certificate
         self.keyfile = keyfile
         self.__key = private_key

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -461,6 +461,7 @@ class NapalmLogs:
                                   self.auth_port)
         proc = Process(target=auth.start)
         proc.start()
+        proc.description = 'Auth process'
         log.debug('Started auth process as %s with PID %s', proc._name, proc.pid)
         return proc
 
@@ -479,6 +480,7 @@ class NapalmLogs:
                                           listener_opts=self.listener_opts)
         proc = Process(target=listener.start)
         proc.start()
+        proc.description = 'Listener process'
         log.debug('Started listener process as %s with PID %s', proc._name, proc.pid)
         return proc
 
@@ -500,6 +502,7 @@ class NapalmLogs:
                                       self.publisher_opts)
         proc = Process(target=server.start)
         proc.start()
+        proc.description = 'Server process'
         log.debug('Started server process as %s with PID %s', proc._name, proc.pid)
         return proc
 
@@ -520,6 +523,7 @@ class NapalmLogs:
                                             disable_security=self.disable_security)
         proc = Process(target=publisher.start)
         proc.start()
+        proc.description = 'Publisher process'
         log.debug('Started publisher process as %s with PID %s', proc._name, proc.pid)
         return proc
 
@@ -541,6 +545,7 @@ class NapalmLogs:
                                    self.publisher_opts)
         os_proc = Process(target=dos.start)
         os_proc.start()
+        os_proc.description = '%s device process' % device_os
         log.debug('Started process %s for %s, having PID %s', os_proc._name, device_os, os_proc.pid)
         return os_proc
 
@@ -599,6 +604,7 @@ class NapalmLogs:
             for process in self._processes:
                 if process.is_alive() is True:
                     continue
+                log.debug('%s is dead. Stopping the napalm-logs engine.', process.description)
                 self.stop_engine()
 
     def stop_engine(self):

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -453,8 +453,7 @@ class NapalmLogs:
         verify_key = self.__signing_key.verify_key
         sgn_verify_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
         log.debug('Starting the authenticator subprocess')
-        auth = NapalmLogsAuthProc(self.opts,
-                                  self.certificate,
+        auth = NapalmLogsAuthProc(self.certificate,
                                   self.keyfile,
                                   self.__priv_key,
                                   sgn_verify_hex,

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -552,7 +552,7 @@ class NapalmLogs:
             self._processes.append(self._start_auth_proc())
         # publisher process start
         # pub_pipe, dev_pub_pipe = Pipe(duplex=False)
-        self._processes.append(self._start_pub_proc(pub_pipe))
+        self._processes.append(self._start_pub_proc())
         # device process start
         log.info('Starting child processes for each device type')
         # os_pipes = {}

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -535,7 +535,6 @@ class NapalmLogs:
         '''
         Start the device worker process.
         '''
-        # TODO remove the pipe overhead when migrating to zmq IPC
         log.info('Starting the child process for %s', device_os)
         dos = NapalmLogsDeviceProc(device_os,
                                    self.opts,

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -13,7 +13,7 @@ import time
 import yaml
 import logging
 import threading
-from multiprocessing import Process, Pipe
+from multiprocessing import Process
 
 # Import third party libs
 # crypto
@@ -577,9 +577,9 @@ class NapalmLogs:
                 continue
             # device_pipe, srv_pipe = Pipe(duplex=False)
             self._processes.append(self._start_dev_proc(device_os,
-                                   device_config))
-                                   # device_pipe,
-                                   # dev_pub_pipe))
+                                                        device_config))
+                                                        # device_pipe,    # noqa
+                                                        # dev_pub_pipe))  # noqa
             started_os_proc.append(device_os)
             # os_pipes[device_os] = srv_pipe
         # start server process

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -5,6 +5,7 @@ Config defaults.
 from __future__ import absolute_import
 
 import os
+import tempfile
 import logging
 import napalm_logs.ext.six as six
 
@@ -101,17 +102,19 @@ DEFAULT_DELIM = '//'
 PROC_DEAD_FLAGS = ('T', 'X', 'Z')
 
 # zmq proxies
-AUTH_IPC_URL = 'ipc:///tmp/napalm-logs-auth'
+TMP_DIR = tempfile.gettempdir()
+AUTH_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-auth'))
 # the auth proxy is not used yet, TODO
-LST_IPC_URL = 'ipc:///tmp/napalm-logs-lst'
-SRV_IPC_URL = 'ipc:///tmp/napalm-logs-srv'
+LST_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-lst'))
+SRV_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-srv'))
 # the publisher IPC is used as proxy
 # the devices send the messages to the proxy
 # and the publisher subscribes to the proxy and
 # publishes them on the desired transport
-DEV_IPC_URL_TPL = 'ipc:///tmp/napalm-logs-dev-{os}'
+DEV_IPC_URL_TPL = 'ipc://{}'.format(os.path.join(TMP_DIR,
+                                                'napalm-logs-dev-{os}'))
 # the server publishes to a separate IPC per device
-PUB_IPC_URL = 'ipc:///tmp/napalm-logs-pub'
+PUB_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-pub'))
 
 # auth
 AUTH_KEEP_ALIVE = b'KEEPALIVE'

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -28,6 +28,8 @@ LOG_LEVEL = 'warning'
 LOG_FORMAT = '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 LOG_FILE = os.path.join(ROOT_DIR, 'var', 'log', 'napalm', 'logs')
 LOG_FILE_CLI_OPTIONS = ('cli', 'screen')
+ZMQ_INTERNAL_HWM = 1000
+
 # Allowed names for the init files.
 OS_INIT_FILENAMES = (
     '__init__',

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -111,8 +111,7 @@ SRV_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-srv'))
 # the devices send the messages to the proxy
 # and the publisher subscribes to the proxy and
 # publishes them on the desired transport
-DEV_IPC_URL_TPL = 'ipc://{}'.format(os.path.join(TMP_DIR,
-                                                'napalm-logs-dev-{os}'))
+DEV_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-dev'))
 # the server publishes to a separate IPC per device
 PUB_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-pub'))
 

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -19,6 +19,7 @@ import umsgpack
 
 # Import napalm-logs pkgs
 import napalm_logs.utils
+import napalm_logs.ext.six as six
 from napalm_logs.proc import NapalmLogsProc
 from napalm_logs.config import PUB_IPC_URL
 from napalm_logs.config import DEV_IPC_URL
@@ -64,7 +65,10 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         # subscribe to device IPC
         log.debug('Creating the dealer IPC for %s', self._name)
         self.sub = self.ctx.socket(zmq.DEALER)
-        self.sub.setsockopt(zmq.IDENTITY, bytes(self._name).encode('utf-8'))
+        if six.PY2:
+            self.sub.setsockopt(zmq.IDENTITY, self._name)
+        elif six.PY3:
+            self.sub.setsockopt(zmq.IDENTITY, bytes(self._name, 'utf-8'))
         try:
             self.sub.setsockopt(zmq.HWM, self.opts['hwm'])
             # zmq 2

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -33,11 +33,16 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
     '''
     Device sub-process class.
     '''
-    def __init__(self, name, config, pipe, pub_pipe, publisher_opts):
+    def __init__(self,
+                 name,
+                 config,
+                 # pipe,
+                 # pub_pipe,
+                 publisher_opts):
         self._name = name
-        self.pipe = pipe
         self._config = config
-        self.pub_pipe = pub_pipe
+        # self.pipe = pipe
+        # self.pub_pipe = pub_pipe
         self.publisher_opts = publisher_opts
         self.__up = False
         self.compiled_messages = None
@@ -319,5 +324,5 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         self.sub.close()
         self.pub.close()
         self.ctx.term()
-        self.pipe.close()
+        # self.pipe.close()
         self.pub_pipe.close()

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -57,7 +57,7 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         # subscribe to device IPC
         log.debug('Creating the dealer IPC for %s', self._name)
         self.sub = self.ctx.socket(zmq.DEALER)
-        self.sub.setsockopt(zmq.IDENTITY, self._name)
+        self.sub.setsockopt(zmq.IDENTITY, bytes(self._name).encode('utf-8'))
         # subscribe to the corresponding IPC pipe
         self.sub.connect(DEV_IPC_URL)
         # self.sub.setsockopt(zmq.SUBSCRIBE, '')

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -29,12 +29,14 @@ class NapalmLogsListenerProc(NapalmLogsProc):
     publisher sub-process class.
     '''
     def __init__(self,
+                 opts,
                  address,
                  port,
                  listener_type,
                  # pipe,
                  listener_opts=None):
         self.__up = False
+        self.opts = opts
         self.address = address
         self.port = port
         # self.pipe = pipe
@@ -62,6 +64,13 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         self.ctx = zmq.Context()
         self.pub = self.ctx.socket(zmq.PUSH)
         self.pub.connect(LST_IPC_URL)
+        log.debug('Setting HWM for the listener: %d', self.opts['hwm'])
+        try:
+            self.pub.setsockopt(zmq.HWM, self.opts['hwm'])
+            # zmq 2
+        except AttributeError:
+            # zmq 3
+            self.pub.setsockopt(zmq.SNDHWM, self.opts['hwm'])
 
     def start(self):
         '''
@@ -80,8 +89,12 @@ class NapalmLogsListenerProc(NapalmLogsProc):
             try:
                 log_message, log_source = self.listener.receive()
             except ListenerException as lerr:
-                # Exit on listener exception.
-                raise NapalmLogsExit(lerr)
+                if self.__up is False:
+                    log.info('Exiting on process shutdown')
+                    return
+                else:
+                    log.error(lerr, exc_info=True)
+                    raise NapalmLogsExit(lerr)
             log.debug('Received %s from %s. Queueing to the server.', log_message, log_source)
             if not log_message:
                 log.info('Empty message received from %s. Not queueing to the server.', log_source)

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -10,7 +10,12 @@ import signal
 import logging
 import threading
 
+# Import third party libs
+import zmq
+import umsgpack
+
 # Import napalm-logs pkgs
+from napalm_logs.config import LST_IPC_URL
 from napalm_logs.proc import NapalmLogsProc
 from napalm_logs.listener import get_listener
 from napalm_logs.exceptions import NapalmLogsExit
@@ -32,7 +37,7 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         self.__up = False
         self.address = address
         self.port = port
-        self.pipe = pipe
+        # self.pipe = pipe
         self._listener_type = listener_type
         self.listener_opts = {} or listener_opts
 
@@ -49,11 +54,20 @@ class NapalmLogsListenerProc(NapalmLogsProc):
                                        self.port,
                                        **self.listener_opts)
 
+    def _setup_ipc(self):
+        '''
+        Setup the listener ICP pusher.
+        '''
+        log.debug('Setting up the listener IPC pusher')
+        self.ctx = zmq.Context()
+        self.pub = self.ctx.socket(zmq.PUSH)
+        self.pub.connect(LST_IPC_URL)
+
     def start(self):
         '''
         Listen to messages and publish them.
         '''
-        # self._setup_ipc()
+        self._setup_ipc()
         log.debug('Using the %s listener', self._listener_type)
         self._setup_listener()
         self.listener.start()
@@ -72,9 +86,11 @@ class NapalmLogsListenerProc(NapalmLogsProc):
             if not log_message:
                 log.info('Empty message received from %s. Not queueing to the server.', log_source)
                 continue
-            self.pipe.send((log_message, log_source))
+            self.pub.send(umsgpack.packb((log_message, log_source)))
 
     def stop(self):
         log.info('Stopping the listener process')
         self.__up = False
+        self.pub.close()
+        self.ctx.term()
         self.listener.stop()

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -32,7 +32,7 @@ class NapalmLogsListenerProc(NapalmLogsProc):
                  address,
                  port,
                  listener_type,
-                 pipe,
+                 # pipe,
                  listener_opts=None):
         self.__up = False
         self.address = address
@@ -93,4 +93,5 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         self.__up = False
         self.pub.close()
         self.ctx.term()
+        # self.pipe.close()
         self.listener.stop()

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -33,7 +33,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
                  address,
                  port,
                  transport_type,
-                 pipe,
+                 # pipe,
                  private_key,
                  signing_key,
                  publisher_opts,
@@ -41,7 +41,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         self.__up = False
         self.address = address
         self.port = port
-        self.pipe = pipe
+        # self.pipe = pipe
         self.disable_security = disable_security
         self._transport_type = transport_type
         self.publisher_opts = publisher_opts
@@ -123,4 +123,4 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         self.__up = False
         self.sub.close()
         self.ctx.term()
-        self.pipe.close()
+        # self.pipe.close()

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -12,7 +12,6 @@ import threading
 
 # Import third party libs
 import zmq
-import umsgpack
 import nacl.utils
 import nacl.secret
 

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -248,6 +248,8 @@ class NapalmLogsServerProc(NapalmLogsProc):
                 # bin_obj = umsgpack.packb(obj)
                 log.debug('Queueing message to %s', dev_os)
                 # self.pubs[dev_os].send(bin_obj)
+                if six.PY3:
+                    dev_os = bytes(dev_os, 'utf-8')
                 self.pub.send_multipart([dev_os,
                                          umsgpack.packb((msg_dict, address))])
                 # self.os_pipes[dev_os].send((msg_dict, address))
@@ -257,7 +259,9 @@ class NapalmLogsServerProc(NapalmLogsProc):
             elif not dev_os and self.publisher_opts.get('send_unknown'):
                 # OS not identified, but the user requested to publish the message as-is
                 log.debug('Publishing message, although not identified, as requested')
-                self.pub.send_multipart([UNKNOWN_DEVICE_NAME,
+                if six.PY3:
+                    dev_os = bytes(UNKNOWN_DEVICE_NAME, 'utf-8')
+                self.pub.send_multipart([dev_os,
                                          umsgpack.packb(({'message': msg}, address))])
                 # self.os_pipes[UNKNOWN_DEVICE_NAME].send(({'message': msg}, address))
             log.info('No action requested. Ignoring.')

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -91,7 +91,7 @@ def client(**config):
         addr=config['publish_address'],
         port=config['publish_port']))
     sock.setsockopt(zmq.SUBSCRIBE, '')
-    sock.setsockopt(zmq.RCVTIMEO, 1000)
+    sock.setsockopt(zmq.RCVTIMEO, 5000)
 
     # auth = napalm_logs.utils.ClientAuth(config['certificate'],
     #                                     address=config['auth_address'],

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -97,24 +97,23 @@ def client(**config):
     #                                     address=config['auth_address'],
     #                                     port=config['auth_port'])
 
-    heat_stop = time.time() + config['heat_time']
-    stop_time = time.time() + config['run_time'] + 2 * config['heat_time']
+    start_time = time.time()
     count = 0
     # while time.time() < heat_stop:
     #     obj = sock.recv()
     #     decrypted = napalm_logs.utils.decrypt(obj, vk, pk)
-    while time.time() < stop_time:
+    while True:
         try:
             obj = sock.recv()
         except zmq.Again:
-            continue
+            break
         log.debug('Received:')
         log.debug(obj)
         decrypted = napalm_logs.utils.unserialize(obj)
         log.debug('Decrypted:')
         log.debug(decrypted)
         count += 1
-    print('Received {0} messages in {1} seconds'.format(count, config['run_time']))
+    print('Received {0} messages in {1} seconds'.format(count, time.time() - start_time))
 
 
 def router_tcp(id, **config):

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -91,27 +91,30 @@ def client(**config):
         addr=config['publish_address'],
         port=config['publish_port']))
     sock.setsockopt(zmq.SUBSCRIBE, '')
+    sock.setsockopt(zmq.RCVTIMEO, 1000)
 
-    auth = napalm_logs.utils.ClientAuth(config['certificate'],
-                                        address=config['auth_address'],
-                                        port=config['auth_port'])
+    # auth = napalm_logs.utils.ClientAuth(config['certificate'],
+    #                                     address=config['auth_address'],
+    #                                     port=config['auth_port'])
 
     heat_stop = time.time() + config['heat_time']
-    stop_time = time.time() + config['run_time']
+    stop_time = time.time() + config['run_time'] + 2 * config['heat_time']
     count = 0
     # while time.time() < heat_stop:
     #     obj = sock.recv()
     #     decrypted = napalm_logs.utils.decrypt(obj, vk, pk)
     while time.time() < stop_time:
-        obj = sock.recv()
+        try:
+            obj = sock.recv()
+        except zmq.Again:
+            continue
         log.debug('Received:')
         log.debug(obj)
-        decrypted = auth.decrypt(obj)
+        decrypted = napalm_logs.utils.unserialize(obj)
         log.debug('Decrypted:')
         log.debug(decrypted)
         count += 1
-    print('Received {0} messages in {1} seconds'.format(count,
-                                                        config['run_time']-config['heat_time']))
+    print('Received {0} messages in {1} seconds'.format(count, config['run_time']))
 
 
 def router_tcp(id, **config):
@@ -162,6 +165,10 @@ def main():
     log.addHandler(screen_logger)
     pop = ProfilerOptionParser()
     config = pop.extra_parse(log, screen_logger)
+    if 'auth_port' not in config:
+        config['auth_port'] = 49018
+    if 'auth_address' not in config:
+        config['auth_address'] = '0.0.0.0'
     cproc = Process(target=client, kwargs=config)
     cproc.start()
     for _ in range(config['routers']):

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -92,16 +92,12 @@ def client(**config):
         port=config['publish_port']))
     sock.setsockopt(zmq.SUBSCRIBE, '')
     sock.setsockopt(zmq.RCVTIMEO, 5000)
-
-    # auth = napalm_logs.utils.ClientAuth(config['certificate'],
-    #                                     address=config['auth_address'],
-    #                                     port=config['auth_port'])
-
+    if not config['disable_security']:
+        auth = napalm_logs.utils.ClientAuth(config['certificate'],
+                                            address=config['auth_address'],
+                                            port=config['auth_port'])
     start_time = time.time()
     count = 0
-    # while time.time() < heat_stop:
-    #     obj = sock.recv()
-    #     decrypted = napalm_logs.utils.decrypt(obj, vk, pk)
     while True:
         try:
             obj = sock.recv()
@@ -109,7 +105,10 @@ def client(**config):
             break
         log.debug('Received:')
         log.debug(obj)
-        decrypted = napalm_logs.utils.unserialize(obj)
+        if config['disable_security']:
+            decrypted = napalm_logs.utils.unserialize(obj)
+        else:
+            decrypted = auth.decrypt(obj)
         log.debug('Decrypted:')
         log.debug(decrypted)
         count += 1
@@ -164,10 +163,6 @@ def main():
     log.addHandler(screen_logger)
     pop = ProfilerOptionParser()
     config = pop.extra_parse(log, screen_logger)
-    if 'auth_port' not in config:
-        config['auth_port'] = 49018
-    if 'auth_address' not in config:
-        config['auth_address'] = '0.0.0.0'
     cproc = Process(target=client, kwargs=config)
     cproc.start()
     for _ in range(config['routers']):


### PR DESCRIPTION
Replace the multiprocess pipe with zmq ipc, but didn't see any obvious improvement (there's some though, but needs extensive testing). Closes https://github.com/napalm-automation/napalm-logs/issues/72.

On my local computer seems that I hit a limit somewhere, as I never can't get beyond 3500 messages received within 10 seconds. Of course, we need to test this on a much more powerful machine, with larger buffers.