### PR TITLE
Device workers

### DIFF
--- a/docs/options/index.rst
+++ b/docs/options/index.rst
@@ -131,6 +131,27 @@ Configuration file example:
 
   config_path: /home/admin/napalm-logs/
 
+.. _configuration-options-device-worker-processes:
+
+``device-worker-processes``: ``1``
+----------------------------------
+
+.. versionadded:: 0.3.0
+
+This option configures the number of worker processes to be started for each
+platform class. For better performances and higher capacity, it is recommended
+to increase this number, which defaults to 1, i.e., by default there will be
+started a single process per platform.
+
+.. note::
+
+    Increasing the number of processes, will imply higher memory consumption.
+
+    For fine-tunning, consider increasing this number, and at the same time
+    exclude (or include) the appropriate platforms, using the following options:
+    :ref:`configuration-options-device-blacklist` and
+    :ref:`configuration-options-device-whitelist`.
+
 .. _configuration-options-disable-security:
 
 ``disable-security``

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -62,7 +62,8 @@ class NapalmLogs:
                  publisher_opts={},
                  device_blacklist=[],
                  device_whitelist=[],
-                 hwm=None):
+                 hwm=None,
+                 device_worker_processes=1):
         '''
         Init the napalm-logs engine.
 
@@ -96,6 +97,7 @@ class NapalmLogs:
         self.publisher_opts = publisher_opts
         self.device_whitelist = device_whitelist
         self.device_blacklist = device_blacklist
+        self.device_worker_processes = device_worker_processes
         self.opts = {}
         self.opts['hwm'] = CONFIG.ZMQ_INTERNAL_HWM if hwm is None else hwm
         # Setup the environment
@@ -580,10 +582,12 @@ class NapalmLogs:
                 # This way we can prevent starting unwanted sub-processes.
                 continue
             # device_pipe, srv_pipe = Pipe(duplex=False)
-            self._processes.append(self._start_dev_proc(device_os,
-                                                        device_config))
-                                                        # device_pipe,    # noqa
-                                                        # dev_pub_pipe))  # noqa
+            log.debug('Will start %d worker processes for %s', self.device_worker_processes, device_os)
+            for proc_index in range(self.device_worker_processes):
+                self._processes.append(self._start_dev_proc(device_os,
+                                                            device_config))
+                                                            # device_pipe,    # noqa
+                                                            # dev_pub_pipe))  # noqa
             started_os_proc.append(device_os)
             # os_pipes[device_os] = srv_pipe
         # start server process

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -192,6 +192,13 @@ class NLOptionParser(OptionParser, object):
                 'higher memory consumption. '
                 'Default: {0}'.format(defaults.ZMQ_INTERNAL_HWM))
         )
+        self.add_option(
+            '-w', '--device-worker-processes',
+            dest='device_worker_processes',
+            type=int,
+            help='Number of wroker processes per device.',
+            default=1
+        )
 
     def convert_env_dict(self, d):
         for k, v in d.items():
@@ -356,7 +363,9 @@ class NLOptionParser(OptionParser, object):
             'publisher_opts': publisher_opts,
             'device_whitelist': device_whitelist,
             'device_blacklist': device_blacklist,
-            'hwm': hwm
+            'hwm': hwm,
+            'device_worker_processes': self.options.device_worker_processes or\
+                                       file_cfg.get('device_worker_processes') or 1
         }
         return cfg
 

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -141,15 +141,19 @@ def router_udp(id, **config):
     Multiple instances of this have to be started,
     sending messages to the same.
     '''
-    skt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    #skt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    context = zmq.Context()
+    skt = context.socket(zmq.PUSH)
+    skt.bind('tcp://{addr}:{port}'.format(
+        addr=config['address'],
+        port=config['port']))
     stop_time = time.time() + config['run_time']
     count = 0
     while time.time() < stop_time:
         log.debug('Sending sample syslog to {0}:{1} via udp'.format(config['address'], config['port']))
         # config['syslog_sample'] = '{timestamp} {id}'
-        skt.sendto(config['syslog_sample'].format(id=str(id*10)+str(count),
-                                                  timestamp=time.time()),
-                   (config['address'], config['port']))
+        skt.send(config['syslog_sample'].format(id=str(id*10)+str(count),
+                                                  timestamp=time.time()))
         count += 1
         time.sleep(1.0/config['pace'])
     print('Sent {0} messages in {1} seconds'.format(count, config['run_time']))


### PR DESCRIPTION
This will start a `device_worker_processes` number of processes for each platform class. There are no further changes required, thanks to the internal ZeroMQ ventilator.