### PR TITLE
Fix `send_unknown` bug

### DIFF
--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -571,7 +571,7 @@ class NapalmLogs:
         # os_pipes = {}
         if self.publisher_opts.get('send_unknown'):
             # Explicitly requested to send messages from unidentified devices.
-            log.info('Starting an additional process to publish messages from identified operating systems.')
+            log.info('Starting an additional process to publish messages from unknown operating systems.')
             self.config_dict[CONFIG.UNKNOWN_DEVICE_NAME] = {}
         started_os_proc = []
         for device_os, device_config in self.config_dict.items():
@@ -582,7 +582,7 @@ class NapalmLogs:
                 # This way we can prevent starting unwanted sub-processes.
                 continue
             # device_pipe, srv_pipe = Pipe(duplex=False)
-            log.debug('Will start %d worker processes for %s', self.device_worker_processes, device_os)
+            log.debug('Will start %d worker process(es) for %s', self.device_worker_processes, device_os)
             for proc_index in range(self.device_worker_processes):
                 self._processes.append(self._start_dev_proc(device_os,
                                                             device_config))

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -42,6 +42,7 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                  # pub_pipe,
                  publisher_opts):
         self._name = name
+        log.debug('Starting process for %s', self._name)
         self._config = config
         self.opts = opts
         # self.pipe = pipe

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -123,7 +123,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
                 else:
                     log.error(error, exc_info=True)
                     raise NapalmLogsExit(error)
-            log.debug('Publishing the OC object (serialised)')
+            log.debug('Publishing the OC object')
             if not self.disable_security and self.__transport_encrypt:
                 bin_obj = self._prepare(bin_obj)
             self.transport.publish(bin_obj)

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -261,6 +261,8 @@ class NapalmLogsServerProc(NapalmLogsProc):
                 log.debug('Publishing message, although not identified, as requested')
                 if six.PY3:
                     dev_os = bytes(UNKNOWN_DEVICE_NAME, 'utf-8')
+                else:
+                    dev_os = UNKNOWN_DEVICE_NAME
                 self.pub.send_multipart([dev_os,
                                          umsgpack.packb(({'message': msg}, address))])
                 # self.os_pipes[UNKNOWN_DEVICE_NAME].send(({'message': msg}, address))

--- a/napalm_logs/transport/cli.py
+++ b/napalm_logs/transport/cli.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import napalm-logs pkgs
+import napalm_logs.utils
 from napalm_logs.transport.base import TransportBase
 
 
@@ -15,5 +16,10 @@ class CLITransport(TransportBase):
     '''
     CLI transport class.
     '''
+    NO_ENCRYPT = True
+    # This tells the publisher to not encrypt the messages
+    #   published over this channel.
+
     def publish(self, obj):
-        print(obj)
+        data = napalm_logs.utils.unserialize(obj)
+        print(data)


### PR DESCRIPTION
@jedelman8 reported that there's an issue when `send_unknown` is configured. The core issue is inide the Server process that didn't explicitly set the Device dealer identification value to `unknown`.
In this PR, I also fixed some issues with the CLI publisher, as we don't need to encrypt / serialise the data on the command line, but it rather needs to be human-readable, not secured, as this pub can't be actually used in prod.