### PR TITLE
Add device config section

### DIFF
--- a/docs/device_config/eos.rst
+++ b/docs/device_config/eos.rst
@@ -1,0 +1,19 @@
+.. _device-configuration-eos:
+
+==========
+Arista EOS
+==========
+
+The following will configure EOS to send the syslog messages, over UDP, to the
+IP Address ``10.10.10.1``, port 10101:
+
+.. code-block::
+
+    logging host 10.10.10.1 10101
+
+To correctly send the hostname information, is is also recommended to explicitly
+configure the following:
+
+.. code-block::
+
+    logging format hostname fqdn

--- a/docs/device_config/eos.rst
+++ b/docs/device_config/eos.rst
@@ -7,13 +7,13 @@ Arista EOS
 The following will configure EOS to send the syslog messages, over UDP, to the
 IP Address ``10.10.10.1``, port 10101:
 
-.. code-block::
+.. code-block:: text
 
     logging host 10.10.10.1 10101
 
 To correctly send the hostname information, is is also recommended to explicitly
 configure the following:
 
-.. code-block::
+.. code-block:: text
 
     logging format hostname fqdn

--- a/docs/device_config/index.rst
+++ b/docs/device_config/index.rst
@@ -1,0 +1,35 @@
+.. _device-configuration:
+
+===================================
+Supported devices and configuration
+===================================
+
+Napalm-logs can process syslog messages from the following network operating
+systems:
+
+.. toctree::
+   :maxdepth: 1
+
+   junos
+   iosxr
+   eos
+   nxos
+
+To see how to configure the network device, check the documents referenced
+above. Note that the examples in each case represents the configuration used to
+send the syslog messages over UDP to a certain IP address and port. Remember
+that napalm-logs is able to receive the messages over UDP (by default), as well
+as via other channels - see :ref:`listener`. While napalm-logs can be the UDP
+endpoint configured to receive the messages straight from the network device,
+there is no standard configuration, setup or architecture for the rest of the
+Listeners, but rather it depends very much on how you want to design your own
+use case.
+
+Napalm-logs is able to publish messages from unidentified operating systems (or
+partially parsed messages), but this behaviour is disabled by default.
+To allow publishing messages from operating systems that are not supported yet
+by napalm-logs (but they will not be parsed at all), you can configure the
+:ref:`publisher-opts-send-unknown` option on the publisher (i.e.,
+``send_unknow: true``). To publish partially parsed messages from supported
+operating systems, but without a mapping for a certain class of messages, you
+can use the :ref:`publisher-opts-send-raw` option.

--- a/docs/device_config/iosxr.rst
+++ b/docs/device_config/iosxr.rst
@@ -1,0 +1,22 @@
+.. _device-configuration-iosxr:
+
+============
+Cisco IOS-XR
+============
+
+The following will configure IOS-XR to send the syslog messages, over UDP, to the
+IP Address ``10.10.10.1``, port 10101:
+
+
+.. code-block::
+
+    logging 10.10.10.1 port 10101
+
+To correctly send the hostname information, is is also recommended to explicitly
+configure the following:
+
+.. code-block::
+
+    logging hostnameprefix <hostname of the device>
+
+Otherwise the device won't send this information.

--- a/docs/device_config/iosxr.rst
+++ b/docs/device_config/iosxr.rst
@@ -8,14 +8,14 @@ The following will configure IOS-XR to send the syslog messages, over UDP, to th
 IP Address ``10.10.10.1``, port 10101:
 
 
-.. code-block::
+.. code-block:: text
 
     logging 10.10.10.1 port 10101
 
 To correctly send the hostname information, is is also recommended to explicitly
 configure the following:
 
-.. code-block::
+.. code-block:: text
 
     logging hostnameprefix <hostname of the device>
 

--- a/docs/device_config/junos.rst
+++ b/docs/device_config/junos.rst
@@ -1,0 +1,13 @@
+.. _device-configuration-junos:
+
+=====
+Junos
+=====
+
+The following will configure Junos to send the syslog messages, over UDP, to the
+IP Address ``10.10.10.1``, port 10101:
+
+
+.. code-block::
+
+    set system syslog host 10.10.10.1 port 10101 any any

--- a/docs/device_config/junos.rst
+++ b/docs/device_config/junos.rst
@@ -8,6 +8,6 @@ The following will configure Junos to send the syslog messages, over UDP, to the
 IP Address ``10.10.10.1``, port 10101:
 
 
-.. code-block::
+.. code-block:: text
 
     set system syslog host 10.10.10.1 port 10101 any any

--- a/docs/device_config/nxos.rst
+++ b/docs/device_config/nxos.rst
@@ -7,6 +7,6 @@ Cisco NX-OS
 The following will configure NX-OS to send the syslog messages, over UDP, to the
 IP Address ``10.10.10.1``, port 10101:
 
-.. code-block::
+.. code-block:: text
 
     logging server 10.10.10.1 port 10101

--- a/docs/device_config/nxos.rst
+++ b/docs/device_config/nxos.rst
@@ -1,0 +1,12 @@
+.. _device-configuration-nxos:
+
+===========
+Cisco NX-OS
+===========
+
+The following will configure NX-OS to send the syslog messages, over UDP, to the
+IP Address ``10.10.10.1``, port 10101:
+
+.. code-block::
+
+    logging server 10.10.10.1 port 10101

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -305,6 +305,7 @@ daemon):
    :maxdepth: 2
 
    installation/index
+   device_config/index
    options/index
    messages/index
    authentication/index


### PR DESCRIPTION
Adds documentation for the supported devices and their configuration.

Closes https://github.com/napalm-automation/napalm-logs/issues/183.