### PR TITLE
changes to get http requests working

### DIFF
--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -77,6 +77,13 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         '''
         Setup the transport.
         '''
+        publisher_address = self.publisher_opts.get('address')
+        publisher_port = self.publisher_opts.get('port')
+        if publisher_address:
+            self.address = self.publisher_opts.pop('address')
+        if publisher_port:
+            self.port = self.publisher_opts.pop('port')
+
         transport_class = get_transport(self._transport_type)
         self.transport = transport_class(self.address,
                                          self.port,

--- a/napalm_logs/transport/http.py
+++ b/napalm_logs/transport/http.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 # Import stdlib
 import logging
 import threading
+import json
 try:
     import Queue as queue
 except ImportError:
@@ -48,7 +49,7 @@ class HTTPTransport(TransportBase):
             self.address = kwargs['address']
         else:
             self.address = address
-        self.method = kwargs.get('method', 'GET')
+        self.method = kwargs.get('method', 'POST')
         log.debug('Publishing to %s using method %s', self.address, self.method)
         self.auth = kwargs.get('auth')
         self.username = kwargs.get('username')
@@ -138,7 +139,7 @@ class HTTPTransport(TransportBase):
                     self.method,
                     self.address,
                     params=self.params,
-                    data=data
+                    data=json.dumps(data)
                 )
                 if not result.ok:
                     log.error('Unable to publish to %s', self.address)


### PR DESCRIPTION
Hey @mirceaulinic 

Per all my messages, here is where I'm at.  Stripped down to a subset of the changes I mentioned via Slack.

* Updated default HTTP method to POST - just seems logical.  However, maybe not a requirement because this is a flag in the config file and CLI.
* When you requests, `data` is a JSON string, it was a dictionary.  Add `json.dumps` for this.
* I added a small code block in `publisher.py` to get it working, but I'm not sure if this breaks anything on your side with Kafka...I thought about going into the transport class and changing the positional args and kwargs, but again, rather have you drive that.  The short of it is that address/port are being over-written in the current code when they're set and not sure that's correct.  From what I can tell kwargs (or `publisher_opts`) are the PUBLISHER options and `address` and `port` are for the listener.  For me this, hack got me up and running, but it would seem good to use keys like `listener_address`, `publisher_address`, etc. to avoid confusion  :) 


