### PR TITLE
Many core changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,7 +241,7 @@ def gen_messages_rst():
     # Start building the docs.
     # Firstly load the messages config, by creating an instance
     #   of the base NapalmLogs class, without starting the engine.
-    nl_ = NapalmLogs()
+    nl_ = NapalmLogs(publisher=[])
     defined_errors = {}
     for os_name, os_cfg in nl_.config_dict.items():
         for message in os_cfg['messages']:

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -135,6 +135,8 @@ class NapalmLogs:
             pub_opts = pub.values()[0]
             if 'only_unknown' in pub_opts and pub[pub_name]['only_unknown']:
                 pub[pub_name]['send_unknown'] = True
+            if 'only_raw' in pub_opts and pub[pub_name]['only_raw']:
+                pub[pub_name]['send_raw'] = True
             if 'send_unknown' in pub_opts and pub[pub_name]['send_unknown']:
                 self.opts['_server_send_unknown'] = True
 

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -131,8 +131,8 @@ class NapalmLogs:
         self.opts['hwm'] = CONFIG.ZMQ_INTERNAL_HWM if self.hwm is None else self.hwm
         self.opts['_server_send_unknown'] = False
         for pub in self.publisher:
-            pub_name = pub.keys()[0]
-            pub_opts = pub.values()[0]
+            pub_name = list(pub.keys())[0]
+            pub_opts = list(pub.values())[0]
             error_whitelist = pub_opts.get('error_whitelist', [])
             error_blacklist = pub_opts.get('error_blacklist', [])
             if 'UNKNOWN' not in error_blacklist:

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -527,6 +527,7 @@ class NapalmLogs:
             self.__signing_key = nacl.signing.SigningKey.generate()
             # start the keepalive thread for the auth sub-process
             self._processes.append(self._start_auth_proc())
+        log.debug('Starting the internal proxy')
         proc = self._start_pub_px_proc()
         self._processes.append(proc)
         # publisher process start
@@ -553,6 +554,7 @@ class NapalmLogs:
                 self._processes.append(self._start_dev_proc(device_os,
                                                             device_config))
             started_os_proc.append(device_os)
+        # start the server process
         self._processes.append(self._start_srv_proc(started_os_proc))
         # start listener process
         for lst in self.listener:

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -24,6 +24,7 @@ AUTH_ADDRESS = '0.0.0.0'
 AUTH_PORT = 49018
 AUTH_MAX_TRY = 5
 AUTH_TIMEOUT = 1
+SERIALIZER = 'msgpack'
 LOG_LEVEL = 'warning'
 LOG_FORMAT = '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 LOG_FILE = os.path.join(ROOT_DIR, 'var', 'log', 'napalm', 'logs')
@@ -44,16 +45,16 @@ INIT_RUN_FUN = 'extract'
 CONFIG_RUN_FUN = 'emit'
 
 UNKNOWN_DEVICE_NAME = 'unknown'
+
 LISTENER_OPTS = {
-    'kafka_topic': 'syslog.net'
 }
+
 LOGGER_OPTS = {
-    'kafka_topic': 'syslog.net.processed',
-    'send_raw': False,  # initially called `syslog`
+    'send_raw': False,
     'send_unknown': False
 }
+
 PUBLISHER_OPTS = {
-    'kafka_topic': 'napalm-logs',
     'send_raw': False,
     'send_unknown': False
 }
@@ -115,6 +116,7 @@ SRV_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-srv'))
 # publishes them on the desired transport
 DEV_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-dev'))
 # the server publishes to a separate IPC per device
+PUB_PX_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-pub-px'))
 PUB_IPC_URL = 'ipc://{}'.format(os.path.join(TMP_DIR, 'napalm-logs-pub'))
 
 # auth

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 # Import python stdlib
 import os
 import re
-import time
 import signal
 import logging
 import threading
@@ -23,7 +22,6 @@ import napalm_logs.ext.six as six
 from napalm_logs.proc import NapalmLogsProc
 from napalm_logs.config import PUB_PX_IPC_URL
 from napalm_logs.config import DEV_IPC_URL
-from napalm_logs.config import UNKNOWN_DEVICE_NAME
 # exceptions
 from napalm_logs.exceptions import NapalmLogsExit
 

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -21,7 +21,7 @@ import umsgpack
 import napalm_logs.utils
 import napalm_logs.ext.six as six
 from napalm_logs.proc import NapalmLogsProc
-from napalm_logs.config import PUB_IPC_URL
+from napalm_logs.config import PUB_PX_IPC_URL
 from napalm_logs.config import DEV_IPC_URL
 from napalm_logs.config import UNKNOWN_DEVICE_NAME
 # exceptions
@@ -37,17 +37,11 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
     def __init__(self,
                  name,
                  opts,
-                 config,
-                 # pipe,
-                 # pub_pipe,
-                 publisher_opts):
+                 config):
         self._name = name
         log.debug('Starting process for %s', self._name)
         self._config = config
         self.opts = opts
-        # self.pipe = pipe
-        # self.pub_pipe = pub_pipe
-        self.publisher_opts = publisher_opts
         self.__up = False
         self.compiled_messages = None
         self._compile_messages()
@@ -78,10 +72,9 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             self.sub.setsockopt(zmq.RCVHWM, self.opts['hwm'])
         # subscribe to the corresponding IPC pipe
         self.sub.connect(DEV_IPC_URL)
-        # self.sub.setsockopt(zmq.SUBSCRIBE, '')
         # publish to the publisher IPC
         self.pub = self.ctx.socket(zmq.PUSH)
-        self.pub.connect(PUB_IPC_URL)
+        self.pub.connect(PUB_PX_IPC_URL)
         try:
             self.pub.setsockopt(zmq.HWM, self.opts['hwm'])
             # zmq 2
@@ -255,25 +248,6 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
                 else:
                     raise NapalmLogsExit(error)
             log.debug('%s: dequeued %s, received from %s', self._name, msg_dict, address)
-            if self._name == UNKNOWN_DEVICE_NAME:
-                # If running in the sub-process publishing messages for unknown OSs.
-                # This will always send what receives, as-is.
-                log.debug('Publishing the message as-is, no further processing possible.')
-                to_publish = {
-                    'ip': address,
-                    'host': 'unknown',
-                    'timestamp': int(time.time()),
-                    'message_details': msg_dict,
-                    'os': UNKNOWN_DEVICE_NAME,
-                    'error': 'UNKNOWN',
-                    'model_name': 'unknown'
-                }
-                log.debug('Queueing to be published:')
-                log.debug(to_publish)
-                # self.pub_pipe.send(to_publish)
-                self.pub.send(umsgpack.packb(to_publish))
-                continue
-            # From here on, we're running in a regular OS sub-process.
             host = msg_dict.get('host')
             prefix_id = msg_dict.pop('__prefix_id__')
             if 'timestamp' in msg_dict:
@@ -289,23 +263,22 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
             kwargs = self._parse(msg_dict)
             if not kwargs:
                 # Unable to identify what model to generate for the message in cause.
-                if self.publisher_opts.get('send_raw'):
-                    # But publish the message when the user requested to push raw messages.
-                    to_publish = {
-                        'ip': address,
-                        'host': host,
-                        'timestamp': timestamp,
-                        'message_details': msg_dict,
-                        'os': self._name,
-                        'error': 'RAW',
-                        'model_name': 'raw',
-                        'facility': facility,
-                        'severity': severity
-                    }
-                    log.debug('Queueing to be published:')
-                    log.debug(to_publish)
-                    # self.pub_pipe.send(to_publish)
-                    self.pub.send(umsgpack.packb(to_publish))
+                # But publish the message when the user requested to push raw messages.
+                to_publish = {
+                    'ip': address,
+                    'host': host,
+                    'timestamp': timestamp,
+                    'message_details': msg_dict,
+                    'os': self._name,
+                    'error': 'RAW',
+                    'model_name': 'raw',
+                    'facility': facility,
+                    'severity': severity
+                }
+                log.debug('Queueing to be published:')
+                log.debug(to_publish)
+                # self.pub_pipe.send(to_publish)
+                self.pub.send(umsgpack.packb(to_publish))
                 continue
             try:
                 if '__python_fun__' in kwargs:

--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -73,7 +73,7 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         # subscribe to the corresponding IPC pipe
         self.sub.connect(DEV_IPC_URL)
         # publish to the publisher IPC
-        self.pub = self.ctx.socket(zmq.PUSH)
+        self.pub = self.ctx.socket(zmq.PUB)
         self.pub.connect(PUB_PX_IPC_URL)
         try:
             self.pub.setsockopt(zmq.HWM, self.opts['hwm'])

--- a/napalm_logs/exceptions.py
+++ b/napalm_logs/exceptions.py
@@ -51,6 +51,20 @@ class InvalidListenerException(ListenerException):
     pass
 
 
+class SerializerException(NapalmLogsException):
+    '''
+    Raised in case of serializer-related errors.
+    '''
+    pass
+
+
+class InvalidSerializerException(SerializerException):
+    '''
+    Raised when the user selects a serializer not available.
+    '''
+    pass
+
+
 class ConfigurationException(NapalmLogsException):
     '''
     Exception thrown when the user configuration is not correct.

--- a/napalm_logs/ext/__init__.py
+++ b/napalm_logs/ext/__init__.py
@@ -75,4 +75,3 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
         return True
 
     return False
-

--- a/napalm_logs/ext/__init__.py
+++ b/napalm_logs/ext/__init__.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+'''
+External modules and functions.
+'''
+from __future__ import absolute_import
+
+import re
+import fnmatch
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def expr_match(line, expr):
+    '''
+    Evaluate a line of text against an expression. First try a full-string
+    match, next try globbing, and then try to match assuming expr is a regular
+    expression. Originally designed to match minion IDs for
+    whitelists/blacklists.
+    '''
+    if line == expr:
+        return True
+    if fnmatch.fnmatch(line, expr):
+        return True
+    try:
+        if re.match(r'\A{0}\Z'.format(expr), line):
+            return True
+    except re.error:
+        pass
+    return False
+
+
+def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
+    '''
+    Check a whitelist and/or blacklist to see if the value matches it.
+
+    value
+        The item to check the whitelist and/or blacklist against.
+
+    whitelist
+        The list of items that are white-listed. If ``value`` is found
+        in the whitelist, then the function returns ``True``. Otherwise,
+        it returns ``False``.
+
+    blacklist
+        The list of items that are black-listed. If ``value`` is found
+        in the blacklist, then the function returns ``False``. Otherwise,
+        it returns ``True``.
+
+    If both a whitelist and a blacklist are provided, value membership
+    in the blacklist will be examined first. If the value is not found
+    in the blacklist, then the whitelist is checked. If the value isn't
+    found in the whitelist, the function returns ``False``.
+    '''
+    if blacklist is not None:
+        if not hasattr(blacklist, '__iter__'):
+            blacklist = [blacklist]
+        try:
+            for expr in blacklist:
+                if expr_match(value, expr):
+                    return False
+        except TypeError:
+            log.error('Non-iterable blacklist {0}'.format(blacklist))
+
+    if whitelist:
+        if not hasattr(whitelist, '__iter__'):
+            whitelist = [whitelist]
+        try:
+            for expr in whitelist:
+                if expr_match(value, expr):
+                    return True
+        except TypeError:
+            log.error('Non-iterable whitelist {0}'.format(whitelist))
+    else:
+        return True
+
+    return False
+

--- a/napalm_logs/pub_proxy.py
+++ b/napalm_logs/pub_proxy.py
@@ -17,32 +17,34 @@ import zmq
 from napalm_logs.config import PUB_IPC_URL
 from napalm_logs.config import PUB_PX_IPC_URL
 from napalm_logs.proc import NapalmLogsProc
+# exceptions
+from napalm_logs.exceptions import NapalmLogsExit
 
 log = logging.getLogger(__name__)
 
 
 class NapalmLogsPublisherProxy(NapalmLogsProc):
     '''
-    Publisher proxy sub-process class.
+    Internal IPC proxy sub-process class.
     '''
     def __init__(self, hwm):
         self.hwm = hwm
         self.__up = False
 
     def _exit_gracefully(self, signum, _):
-        log.debug('Caught signal in the listener process')
+        log.debug('Caught signal in the internal proxy process')
         self.stop()
 
     def _setup_ipc(self):
         '''
-        Setup the listener ICP pusher.
+        Setup the IPC PUB and SUB sockets for the proxy.
         '''
-        log.debug('Setting up the listener IPC proxy')
+        log.debug('Setting up the internal IPC proxy')
         self.ctx = zmq.Context()
         # Frontend
-        self.sub = self.ctx.socket(zmq.PULL)
+        self.sub = self.ctx.socket(zmq.SUB)
         self.sub.bind(PUB_PX_IPC_URL)
-        # self.sub.setsockopt(zmq.SUBSCRIBE, '')
+        self.sub.setsockopt(zmq.SUBSCRIBE, '')
         log.debug('Setting HWM for the proxy frontend: %d', self.hwm)
         try:
             self.sub.setsockopt(zmq.HWM, self.hwm)
@@ -51,9 +53,9 @@ class NapalmLogsPublisherProxy(NapalmLogsProc):
             # zmq 3
             self.sub.setsockopt(zmq.SNDHWM, self.hwm)
         # Backend
-        self.pub = self.ctx.socket(zmq.PUSH)
-        self.pub.connect(PUB_PX_IPC_URL)
-        log.debug('Setting HWM for the proxy frontend: %d', self.hwm)
+        self.pub = self.ctx.socket(zmq.PUB)
+        self.pub.bind(PUB_IPC_URL)
+        log.debug('Setting HWM for the proxy backend: %d', self.hwm)
         try:
             self.pub.setsockopt(zmq.HWM, self.hwm)
             # zmq 2
@@ -70,10 +72,18 @@ class NapalmLogsPublisherProxy(NapalmLogsProc):
         thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
         thread.start()
         signal.signal(signal.SIGTERM, self._exit_gracefully)
-        zmq.proxy(self.sub, self.pub)
+        try:
+            zmq.proxy(self.sub, self.pub)
+        except zmq.ZMQError as error:
+            if self.__up is False:
+                log.info('Exiting on process shutdown')
+                return
+            else:
+                log.error(error, exc_info=True)
+                raise NapalmLogsExit(error)
 
     def stop(self):
-        log.info('Stopping the publisher proxy')
+        log.info('Stopping the internal IPC proxy')
         self.__up = False
         self.sub.close()
         self.pub.close()

--- a/napalm_logs/pub_proxy.py
+++ b/napalm_logs/pub_proxy.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+'''
+Listener worker process
+'''
+from __future__ import absolute_import
+
+# Import pythond stdlib
+import os
+import signal
+import logging
+import threading
+
+# Import third party libs
+import zmq
+
+# Import napalm-logs pkgs
+from napalm_logs.config import PUB_IPC_URL
+from napalm_logs.config import PUB_PX_IPC_URL
+from napalm_logs.proc import NapalmLogsProc
+
+log = logging.getLogger(__name__)
+
+
+class NapalmLogsPublisherProxy(NapalmLogsProc):
+    '''
+    Publisher proxy sub-process class.
+    '''
+    def __init__(self, hwm):
+        self.hwm = hwm
+        self.__up = False
+
+    def _exit_gracefully(self, signum, _):
+        log.debug('Caught signal in the listener process')
+        self.stop()
+
+    def _setup_ipc(self):
+        '''
+        Setup the listener ICP pusher.
+        '''
+        log.debug('Setting up the listener IPC proxy')
+        self.ctx = zmq.Context()
+        # Frontend
+        self.sub = self.ctx.socket(zmq.PULL)
+        self.sub.bind(PUB_PX_IPC_URL)
+        # self.sub.setsockopt(zmq.SUBSCRIBE, '')
+        log.debug('Setting HWM for the proxy frontend: %d', self.hwm)
+        try:
+            self.sub.setsockopt(zmq.HWM, self.hwm)
+            # zmq 2
+        except AttributeError:
+            # zmq 3
+            self.sub.setsockopt(zmq.SNDHWM, self.hwm)
+        # Backend
+        self.pub = self.ctx.socket(zmq.PUSH)
+        self.pub.connect(PUB_PX_IPC_URL)
+        log.debug('Setting HWM for the proxy frontend: %d', self.hwm)
+        try:
+            self.pub.setsockopt(zmq.HWM, self.hwm)
+            # zmq 2
+        except AttributeError:
+            # zmq 3
+            self.pub.setsockopt(zmq.SNDHWM, self.hwm)
+
+    def start(self):
+        '''
+        Listen to messages and publish them.
+        '''
+        self._setup_ipc()
+        # Start suicide polling thread
+        thread = threading.Thread(target=self._suicide_when_without_parent, args=(os.getppid(),))
+        thread.start()
+        signal.signal(signal.SIGTERM, self._exit_gracefully)
+        zmq.proxy(self.sub, self.pub)
+
+    def stop(self):
+        log.info('Stopping the publisher proxy')
+        self.__up = False
+        self.sub.close()
+        self.pub.close()
+        self.ctx.term()

--- a/napalm_logs/publisher.py
+++ b/napalm_logs/publisher.py
@@ -51,7 +51,7 @@ class NapalmLogsPublisherProc(NapalmLogsProc):
         self.port = publisher_opts.pop('port', None) or port
         log.debug('Publishing to %s:%d', self.address, self.port)
         self.serializer = publisher_opts.get('serializer') or serializer
-        self.default_serializer = serializer == SERIALIZER
+        self.default_serializer = self.serializer == SERIALIZER
         self.disable_security = publisher_opts.get('disable_security', disable_security)
         self._transport_type = transport_type
         self.publisher_opts = publisher_opts

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -189,7 +189,7 @@ class NLOptionParser(OptionParser, object):
             '-w', '--device-worker-processes',
             dest='device_worker_processes',
             type=int,
-            help='Number of wroker processes per device.',
+            help='Number of worker processes per device. Default: 1.',
             default=1
         )
 

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -264,7 +264,6 @@ class NLOptionParser(OptionParser, object):
         # For each module we need to merge the defaults with the
         # config file, but prefer the config file
         listener_opts = defaults.LISTENER_OPTS
-        logger_opts = defaults.LOGGER_OPTS
         publisher_opts = defaults.PUBLISHER_OPTS
         device_whitelist = file_cfg.get('device_whitelist', [])
         device_blacklist = file_cfg.get('device_blacklist', [])

--- a/napalm_logs/serializer/__init__.py
+++ b/napalm_logs/serializer/__init__.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 # Import python std lib
 import json
 import yaml
+import pprint
 import logging
 
 # Import third party libs
@@ -25,6 +26,7 @@ SERIALIZER_LOOKUP = {
     'json': json.dumps,
     'str': str,
     'yaml': yaml.safe_dump,
+    'pprint': pprint.pformat,
     '*': umsgpack.packb  # default serializer
 }
 

--- a/napalm_logs/serializer/__init__.py
+++ b/napalm_logs/serializer/__init__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 # Import python std lib
 import json
+import yaml
 import logging
 
 # Import third party libs
@@ -23,6 +24,7 @@ SERIALIZER_LOOKUP = {
     'msgpack': umsgpack.packb,
     'json': json.dumps,
     'str': str,
+    'yaml': yaml.safe_dump,
     '*': umsgpack.packb  # default serializer
 }
 

--- a/napalm_logs/serializer/__init__.py
+++ b/napalm_logs/serializer/__init__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+'''
+napalm-logs pluggable serializer.
+'''
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+# Import python std lib
+import json
+import logging
+
+# Import third party libs
+import umsgpack
+
+# Import napalm-logs pkgs
+# Exceptions
+from napalm_logs.exceptions import InvalidSerializerException
+
+
+log = logging.getLogger(__file__)
+
+SERIALIZER_LOOKUP = {
+    'msgpack': umsgpack.packb,
+    'json': json.dumps,
+    'str': str,
+    '*': umsgpack.packb  # default serializer
+}
+
+
+def get_serializer(name):
+    '''
+    Return the serialize function.
+    '''
+    try:
+        log.debug('Using %s as serializer', name)
+        return SERIALIZER_LOOKUP[name]
+    except KeyError:
+        msg = 'Serializer {} is not available'.format(name)
+        log.error(msg, exc_info=True)
+        raise InvalidSerializerException(msg)
+
+
+__all__ = (
+    'get_listener',
+)

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 # Import pythond stdlib
 import os
 import re
-import json
 import time
 import signal
 import logging
@@ -24,7 +23,6 @@ from napalm_logs.config import DEV_IPC_URL
 from napalm_logs.config import PUB_PX_IPC_URL
 from napalm_logs.config import UNKNOWN_DEVICE_NAME
 from napalm_logs.proc import NapalmLogsProc
-from napalm_logs.transport import get_transport
 # exceptions
 from napalm_logs.exceptions import NapalmLogsExit
 

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -78,7 +78,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
             # zmq 3
             self.pub.setsockopt(zmq.SNDHWM, self.opts['hwm'])
         # Pipe to the publishers
-        self.publisher_pub = self.ctx.socket(zmq.PUSH)
+        self.publisher_pub = self.ctx.socket(zmq.PUB)
         self.publisher_pub.connect(PUB_PX_IPC_URL)
         try:
             self.publisher_pub.setsockopt(zmq.HWM, self.opts['hwm'])

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -227,7 +227,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
             elif dev_os and dev_os not in self.started_os_proc:
                 # Identified the OS, but the corresponding process does not seem to be started.
                 log.info('Unable to queue the message to %s. Is the sub-process started?', dev_os)
-            elif not dev_os:
+            elif not dev_os and self.opts['_server_send_unknown']:
                 # OS not identified, but the user requested to publish the message as-is
                 log.debug('Unable to identify the OS, sending directly to the publishers')
                 to_publish = {

--- a/napalm_logs/transport/cli.py
+++ b/napalm_logs/transport/cli.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import napalm-logs pkgs
-import napalm_logs.utils
 from napalm_logs.transport.base import TransportBase
 
 
@@ -21,5 +20,4 @@ class CLITransport(TransportBase):
     #   published over this channel.
 
     def publish(self, obj):
-        data = napalm_logs.utils.unserialize(obj)
-        print(data)
+        print(obj)

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -352,3 +352,4 @@ def dictupdate(dest, upd):
             for k in upd:
                 dest[k] = upd[k]
         return dest
+

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -352,4 +352,3 @@ def dictupdate(dest, upd):
             for k in upd:
                 dest[k] = upd[k]
         return dest
-

--- a/tests/napalm-logs-profile
+++ b/tests/napalm-logs-profile
@@ -63,7 +63,7 @@ class ProfilerOptionParser(NLOptionParser):
             help=('Total test time. Default: {0}'.format(RUN_TIME))
         )
         self.add_option(
-            '-s', '--syslog-sample',
+            '-k', '--syslog-sample',
             dest='syslog_sample',
             help=('Syslog sample message. Default: {0}'.format(SYSLOG_MSG))
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -41,6 +41,21 @@ def _generate_test_keys():
     return priv_key, sgn_verify_hex
 
 
+def _start_proc(port=49018):
+    '''
+    Helper to start a process where we run the napalm-logs authenticator.
+    '''
+    pk, sgn_key = _generate_test_keys()
+    nlap = NapalmLogsAuthProc('tests/auth/server.crt',
+                              'tests/auth/server.key',
+                              pk,
+                              sgn_key,
+                              auth_port=port)
+    proc = Process(target=nlap.start)
+    proc.start()
+    return proc
+
+
 def test_invalid_cert():
     '''
     Testing if the auth process dies when
@@ -78,44 +93,35 @@ def test_successful_start():
     Test that the auth process can start properly
     when valid certificate and key are configured.
     '''
-    global AUTH_PROC
-    pk, sgn_key = _generate_test_keys()
-    nlap = NapalmLogsAuthProc('tests/auth/server.crt',
-                              'tests/auth/server.key',
-                              pk,
-                              sgn_key)
-    AUTH_PROC = Process(target=nlap.start)
-    AUTH_PROC.start()
-
+    proc = _start_proc(port=49018)
+    proc.stop()
 
 def test_twice_bind():
     '''
     Test that binding twice on the same host/port fails,
     and raises napalm_logs.exceptions.BindException.
     '''
-    pk, sgn_key = _generate_test_keys()
-    nlap = NapalmLogsAuthProc('tests/auth/server.crt',
-                              'tests/auth/server.key',
-                              pk,
-                              sgn_key)
-    assert AUTH_PROC.is_alive()
+    proc1 = _start_proc(port=49019)
+    assert proc1.is_alive()
     time.sleep(.1)  # waiting for the auth socket
     with pytest.raises(napalm_logs.exceptions.BindException):
-        nlap.start()
-    nlap.stop()
+        proc2 = _start_proc(port=49019)
+    proc1.stop()
 
 
 def test_client_auth_fail_wrong_port():
     '''
     Test client connect failure on wrong server port.
     '''
-    assert AUTH_PROC.is_alive()
+    proc = _start_proc(port=49020)
+    time.sleep(.1)
     with pytest.raises(napalm_logs.exceptions.ClientConnectException):
         client = ClientAuth('tests/auth/server.crt',
                             port=1234,
                             max_try=1,
                             timeout=.1)
         client.stop()
+    proc.stop()
 
 
 def test_client_auth():
@@ -123,10 +129,11 @@ def test_client_auth():
     Test the auth process startup and a client
     that retrieves the pk and sgn key.
     '''
-    assert AUTH_PROC.is_alive()
+    proc = _start_proc(port=49021)
     time.sleep(.1)  # waiting for the auth socket
-    client = ClientAuth('tests/auth/server.crt')
+    client = ClientAuth('tests/auth/server.crt', port=49021)
     client.stop()
+    proc.stop()
 
 
 def test_client_keep_alive():
@@ -134,10 +141,12 @@ def test_client_keep_alive():
     Test that the client receives keepalives from
     the auth process.
     '''
-    assert AUTH_PROC.is_alive()
+    proc = _start_proc(port=49022)
+    time.sleep(.1)
     client = ClientAuth('tests/auth/server.crt',
                         max_try=1,
-                        timeout=.1)
+                        timeout=.1,
+                        port=49022)
     time.sleep(.1)  # wait for the client socket
     client.ssl_skt.close()  # force client socket close
     # wait for another keepalive exchange
@@ -146,12 +155,4 @@ def test_client_keep_alive():
     # client.stop() tries to close the auth SSL socket
     # if not alive anymore, this will raise an exception
     # therefore the test will fail
-
-
-def test_successful_stop():
-    '''
-    Test if able to stop properly the auth process.
-    '''
-    assert AUTH_PROC.is_alive()
-    AUTH_PROC.terminate()
-    AUTH_PROC.join()
+    proc.stop()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,6 +47,7 @@ def startup_proc():
     NL_BASE = NapalmLogs(disable_security=True,
                          address=NAPALM_LOGS_TEST_ADDR,
                          port=NAPALM_LOGS_TEST_PORT,
+                         publisher=[{'zmq': {}}],
                          publish_address=NAPALM_LOGS_TEST_PUB_ADDR,
                          publish_port=NAPALM_LOGS_TEST_PUB_PORT,
                          log_level=NAPALM_LOGS_TEST_LOG_LEVEL)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,6 +48,7 @@ def startup_proc():
                          address=NAPALM_LOGS_TEST_ADDR,
                          port=NAPALM_LOGS_TEST_PORT,
                          publisher=[{'zmq': {}}],
+                         listener=[{'udp': {}}],
                          publish_address=NAPALM_LOGS_TEST_PUB_ADDR,
                          publish_port=NAPALM_LOGS_TEST_PUB_PORT,
                          log_level=NAPALM_LOGS_TEST_LOG_LEVEL)


### PR DESCRIPTION
This PR does a couple of things:

1. Adds the ability to start multiple listeners and publishers.
2. Removes the `logger` interface, as the logger is a publisher, and since we introduced multiple publishers, this felt a bit redundant.
3. To be able to publish the messages on multiple channels, it was needed an additional ZMQ Proxy process.
4. Adds another option `serializer` which can be used to select the serializer. Currently you can choose between `msgpack`, `json`, and `str`.
5. Removes various dead code.

/todo Document the removal of the `logger` interface in the release notes, and how to replace it.
/todo Document new `serializer` option.
/todo The listener should send unknown messages to the pub socket only if there's at least one process waiting for unknown/raw messages.
/todo The add option `only_unknown` for the logger-type publisher that shouldn't send anything else than the unknown messages. `only_unkown` implies `send_unknown`. Document this option.
/todo update Kafka lst/pub local opts.