### PR TITLE
Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM alpine:3.6
+MAINTAINER Nathan Catania <nathan@nathancatania.com>
+
+ENV NAPALM_LOGS_DOCKER_VERSION 0.3.0
+
+# Copy script to generate Napalm-logs configuration dynamically
+ADD     startnapalm.sh /usr/bin/startnapalm.sh
+COPY    napalm.tmpl /usr/bin/napalm.tmpl
+
+# Install napalm-logs and pre-requisites
+RUN apk add --no-cache \
+    libffi \
+    libffi-dev \
+    python \
+    python-dev \
+    py-pip \
+    build-base \
+    && pip install envtpl \
+    && pip install cffi \
+    && pip install kafka \
+    && pip install napalm-logs \
+    && chmod 777 /usr/bin/startnapalm.sh \
+    && mkdir -p /tmp/napalm-logs
+
+EXPOSE 514/udp
+
+# Default configuration to be rendered
+ENV PUBLISH_PORT=49017 \
+    KAFKA_BROKER_HOST=127.0.0.1 \
+    KAFKA_BROKER_PORT=9092 \
+    KAFKA_TOPIC=syslog.net \
+    SEND_UNKNOWN=false \
+    SEND_RAW=true \
+    WORKER_PROCESSES=1
+
+CMD /usr/bin/startnapalm.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,80 @@
+# Docker support for Napalm-logs
+The files in this directory help facilitate deploying a containerized version of Napalm-logs using Docker.
+
+The default configuration will allow you to publish to Kafka. If you wish to change this, clone the repository and edit the `Dockerfile` and `napalm.tmpl` files.
+
+
+## Usage
+- The default configuration will publish messages to a Kafka broker located at `127.0.0.1:9092` to a topic `syslog.net`.
+- The container will map internal port 514 to port 514 on the host and listen for incoming messages.
+   - You can change the port which Docker maps to the internal 514 port at container runtime.
+   - This provides an easy way to change what port incoming messages are received on.
+- Security is __disabled__ by default. Do not used the default configuration in a production environment!
+
+[A pre-built Docker image is also available on Docker Hub.](https://hub.docker.com/r/nathancatania/napalm-logs/)
+
+### Customize your configuration
+- The `napalm.tmpl` file is rendered at container runtime and used as the configuration file.
+- All required changes to the configuration should go into this file.
+- Any options specified inside `{{ }}` can be dynamically set using ENV variables either within the Dockerfile, or by specifying the `-e` variable at container runtime.
+- If you require additonal files to be added to the Docker container (eg: Certificate files), you can add in additional `COPY` commands within the Dockerfile.
+
+### Build the image
+1. Navigate to the directory containing the Dockerfile.
+2. Execute:
+```
+docker build napalm-logs:latest .
+```
+This will build the image tagged as `napalm-logs:latest`.
+
+### Run the image
+To run the image with the default configuration:
+```
+docker run -d -p 514:514/udp napalm-logs:latest
+```
+- This will deploy a single container instance and begin listening for incoming messages on port 514 of the host.
+- The default configuration specifies a Kafka broker running on `127.0.0.1` on port 9092, with all data being published to the `syslog.net` topic.
+- You can change these defaults by specifying ENV variables at runtime. See the __Variables__ section below.
+
+### Using the pre-built image
+[A pre-built Docker image is also available on Docker Hub.](https://hub.docker.com/r/nathancatania/napalm-logs/)
+
+Usage:
+```
+docker run -d -p 514:514/udp -i nathancatania/napalm-logs:latest
+```
+The pre-built image allows the variables specified in the __Variables__ section below to be altered.
+
+
+## Variables
+By default, the container listens to UDP traffic on port 514 and will push it to a Kafka broker running on `localhost:9092`.
+
+You can change this by overwriting the ENV variables when launching the container. A list of available variables (and their defaults) is below.
+```yaml
+PUBLISH_PORT: 49017              # Port to publish data to Kafka on
+KAFKA_BROKER_HOST: 127.0.0.1     # Hostname or IP of the Kafka broker to publish to
+KAFKA_BROKER_PORT: 9092          # Port of the Kafka broker to publish to
+KAFKA_TOPIC: syslog.net          # The Kafka topic to push data to.
+SEND_RAW: true                   # Publish messages where the OS, but NOT the message could be identified.
+SEND_UNKNOWN: false              # Publish messages where both OS and message could not be identified.
+WORKER_PROCESSES: 1              # Increasing this increases memory consumption but is better for higher loads.
+```
+If you want to change the port that the container listens on to receive Syslog data, you can alter the port mapping on container launch.
+
+Example (changing the ENV variables and port mapping):
+```
+docker run -d -e KAFKA_BROKER_HOST=192.168.1.200 -e KAFKA_TOPIC=my_topic -p 6000:514/udp -i napalm-logs:latest
+```
+In this example:
+- Internally the container is still listening on port 514, however Docker will map this to external port 6000 on the host. As the user, you will direct your Syslog traffic to port 6000.
+- Napalm-logs will connect to a Kafka broker located at `192.168.1.200`.
+- As the `KAFKA_BROKER_PORT` variable was NOT included, the default port of 9092 will be used for the Kafka broker connection.
+- Data will be published to the Kafka topic `my_topic`.
+
+
+## Security
+The default configuration will execute napalm-logs with the `--disable-security option` enabled.
+Do __NOT__ use this for production. Consult the [napalm-logs documentation](http://napalm-logs.readthedocs.io/en/latest/authentication/index.html) on how to add a certificate & keyfile.
+
+## Altering the Configuration
+If you don't want to output to Kafka, you can change the configuration in the napalm.tmpl file. This file is rendered when the container starts based on the ENV variables defined in the Dockerfile (or those specified at runtime).

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,9 +9,9 @@ The default configuration will allow you to publish to Kafka. If you wish to cha
 - The container will map internal port 514 to port 514 on the host and listen for incoming messages.
    - You can change the port which Docker maps to the internal 514 port at container runtime.
    - This provides an easy way to change what port incoming messages are received on.
-- Security is __disabled__ by default. Do not used the default configuration in a production environment!
 
 [A pre-built Docker image is also available on Docker Hub.](https://hub.docker.com/r/nathancatania/napalm-logs/)
+Security is disabled by default in the pre-built image. As such, it is recommended for testing use only; not deployment in production.
 
 ### Customize your configuration
 - The `napalm.tmpl` file is rendered at container runtime and used as the configuration file.

--- a/docker/napalm.tmpl
+++ b/docker/napalm.tmpl
@@ -1,0 +1,14 @@
+disable_security: true
+config-path: /tmp/napalm-logs/config/
+address: 0.0.0.0
+port: 514
+publish_address: 0.0.0.0
+publish_port: {{PUBLISH_PORT}}
+device-worker-processes: {{WORKER_PROCESSES}}
+publisher:
+  kafka:
+    topic: {{KAFKA_TOPIC}}
+    send_raw: {{SEND_RAW}}
+    send_unknown: {{SEND_UNKNOWN}}
+    bootstrap_servers:
+      - {{KAFKA_BROKER_HOST}}:{{KAFKA_BROKER_PORT}}

--- a/docker/startnapalm.sh
+++ b/docker/startnapalm.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+envtpl --keep-template /usr/bin/napalm.tmpl -o /tmp/napalm-logs/napalm.conf
+napalm-logs --config-file /tmp/napalm-logs/napalm.conf

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,8 +1,8 @@
 .. _installation:
 
-===========
-Instalation
-===========
+============
+Installation
+============
 
 Creating a Virtualenv
 +++++++++++++++++++++
@@ -33,3 +33,45 @@ Now install napalm-logs using pip:
 .. code-block:: bash
 
     pip install napalm-logs
+
+Docker
+++++++++++++++++++++++
+
+Napalm-logs can also be deployed via a Docker container.
+
+`A Dockerfile has been made available in the GitHub repository <https://github.com/napalm-automation/napalm-logs/tree/master/docker>`_ allowing the configuration of the container to be customized.
+
+Alternatively, `a pre-built image is available on Docker Hub <https://hub.docker.com/r/nathancatania/napalm-logs/>`_ which uses the UDP listener and publishes to Kafka by default.
+The pre-built image is recommended for testing only as Napalm-logs is executed with security disabled by default.
+
+Usage:
+
+.. code-block:: bash
+
+    docker run -d -p 6000:514/udp -i nathancatania/napalm-logs:latest
+
+The above command will run the Napalm-logs container and listen on port 6000 (UDP) for incoming messages. By default, the pre-built container attempts to connect to a Kafka broker located at `127.0.0.1:9092` and will publish data to the `syslog.net` topic.
+
+These defaults can be changed by specifying ENV variables at container runtime. For example:
+
+.. code-block:: bash
+
+    docker run -d -e KAFKA_BROKER_HOST=192.168.1.200 -e KAFKA_BROKER_PORT=9094 -e KAFKA_TOPIC=my_topic -p 55555:514/udp -i nathancatania/napalm-logs:latest
+
+In this example:
+
+* The container will listen on port 55555 for incoming messages.
+* Napalm-logs will connect to a Kafka broker located at `192.168.1.200:9094`.
+* Data will be published to the Kafka topic `my_topic`.
+
+A list of available variables which can be changed is included below:
+
+.. code-block:: yaml
+
+    PUBLISH_PORT: 49017              # Source port of the host to publish data to Kafka on
+    KAFKA_BROKER_HOST: 127.0.0.1     # Hostname or IP of the Kafka broker to publish to
+    KAFKA_BROKER_PORT: 9092          # Port of the Kafka broker to publish to
+    KAFKA_TOPIC: syslog.net          # The Kafka topic to push data to.
+    SEND_RAW: true                   # Publish messages where the OS, but NOT the message could be identified.
+    SEND_UNKNOWN: false              # Publish messages where both OS and message could not be identified.
+    WORKER_PROCESSES: 1              # Increasing this increases memory consumption but is better for higher loads.


### PR DESCRIPTION
- Add new root directory `docker` which contains a Dockerfile, the configuration template for building a Napalm-logs Docker image, and the start script used by the image to dynamically render the configuration file.
- Add `README.md` in the `docker` directory which explains usage.
- Modify `docs/installation/index.rst`:
   - Fix small typo with main section heading.
   - Add section on deploying via Docker.