### PR TITLE
Add check to see if timestamp is in future

### DIFF
--- a/napalm_logs/device.py
+++ b/napalm_logs/device.py
@@ -11,7 +11,7 @@ import time
 import signal
 import logging
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # Import thrid party libs
 import zmq
@@ -225,6 +225,11 @@ class NapalmLogsDeviceProc(NapalmLogsProc):
         else:
             year = datetime.now().year
             parsed_time = datetime.strptime('{} {} {}'.format(year, date, time), '%Y {}'.format(time_format))
+            # If the timestamp is in the future then it is likely that the year
+            # is wrong. We subtract 1 day from the parsed time to eleminate any
+            # difference between clocks.
+            if parsed_time - timedelta(days=1) > datetime.now():
+                parsed_time = datetime.strptime('{} {} {}'.format(year - 1, date, time), '%Y {}'.format(time_format))
         return int((parsed_time - datetime(1970, 1, 1)).total_seconds())
 
     def start(self):


### PR DESCRIPTION
This goes part way to fixing #204

Currently if the message that we receive does not contain the year we
assume that it is from the current year. This will only really cause an
issue (other than the failing tests) when we are changing years; if a
log is generated at 23:59:59 on 31st dec and received a second later
than the timestamp will be almost a year out.