### PR TITLE
Remote timestamp key before testing yang outputs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,7 +151,16 @@ def test_config(os_name, error_name, test_case):
     deserialised_zmq_msg = napalm_logs.utils.unserialize(zmq_msg)
     log.debug('Received from the napalm-logs daemon:')
     log.debug(deserialised_zmq_msg)
-    assert struct_yang_message == json.loads(json.dumps(deserialised_zmq_msg))
+    returned_yang = json.loads(json.dumps(deserialised_zmq_msg))
+    # Pop the timestamp from both as most syslog messages do not specify year
+    # which means that once a year we will have to update all tests if we
+    # check the timestamp.
+    # We still expect both to contain a timestamp though.
+    assert struct_yang_message.pop('timestamp', False),\
+        'Yang test file does not contain a timestamp key for {} under {}'.format(error_name, os_name)
+    assert returned_yang.pop('timestamp', False),\
+        'The returned yang does not contain a timestamp key for {} under {}'.format(error_name, os_name)
+    assert struct_yang_message == returned_yang
 
 
 def test_napalm_logs_shut():


### PR DESCRIPTION
Most syslog messages do not contain a year. This means that
`napalm-logs` has to guess the year, most of the time it will use the
current year. This means that any tests added over a year ago will fail
due to the timestamps not matching. We could manipulate the timestamp in
the test code, but I see no point in doing this as we would need to use
a similar logic in the test code as we do in the actual code to generate
the expected timestamp, which is pointless. The other alternative is to
update the timestamps every year, but this doesn't sound very sensible.