### PR TITLE
Update the junos interface regex to allow for breakout ports

### DIFF
--- a/napalm_logs/config/junos/BPDU_BLOCK_INTERFACE_DISABLED.yml
+++ b/napalm_logs/config/junos/BPDU_BLOCK_INTERFACE_DISABLED.yml
@@ -6,7 +6,7 @@ messages:
   - error: BPDU_BLOCK_INTERFACE_DISABLED
     tag: ESWD_BPDU_BLOCK_ERROR_DISABLED
     values:
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\.\:]+(?<!\:))
     line: '{interface}: bpdu-block disabled port'
     model: openconfig-interface
     mapping:

--- a/napalm_logs/config/junos/INTERFACE_DOWN.yml
+++ b/napalm_logs/config/junos/INTERFACE_DOWN.yml
@@ -9,7 +9,7 @@ messages:
       adminStatusValue: (\d)
       operStatusString|upper: (\w+)
       operStatusValue: (\d)
-      interface: ([\w\-\/]+)
+      interface: ([\w\-\/\:]+)
     line: 'ifIndex {snmpID}, ifAdminStatus {adminStatusString}({adminStatusValue}), ifOperStatus {operStatusString}({operStatusValue}), ifName {interface}'
     model: openconfig-interfaces
     mapping:

--- a/napalm_logs/config/junos/INTERFACE_MAC_LIMIT_REACHED.yml
+++ b/napalm_logs/config/junos/INTERFACE_MAC_LIMIT_REACHED.yml
@@ -6,7 +6,7 @@ messages:
   - error: INTERFACE_MAC_LIMIT_REACHED
     tag: L2ALD_MAC_LIMIT_REACHED_IF
     values:
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       count: (\d+)
     line: 'Limit on learned MAC addresses reached for {interface}; current count is {count}'
     model: openconfig-interface

--- a/napalm_logs/config/junos/OSPF_NEIGHBOR_DOWN.yml
+++ b/napalm_logs/config/junos/OSPF_NEIGHBOR_DOWN.yml
@@ -7,7 +7,7 @@ messages:
     tag: RPD_OSPF_NBRDOWN
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Full to Down due to KillNbr (event reason: {reasonMessage})'
@@ -23,7 +23,7 @@ messages:
     tag: RPD_OSPF_NBRDOWN
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Full to Down due to InActiveTimer (event reason: {reasonMessage})'

--- a/napalm_logs/config/junos/OSPF_NEIGHBOR_UP.yml
+++ b/napalm_logs/config/junos/OSPF_NEIGHBOR_UP.yml
@@ -7,7 +7,7 @@ messages:
     tag: RPD_OSPF_NBRUP
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Init to ExStart due to 2WayRcvd (event reason: {reasonMessage})'
@@ -23,7 +23,7 @@ messages:
     tag: RPD_OSPF_NBRUP
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Init to 2Way due to 2WayRcvd (event reason: {reasonMessage})'
@@ -39,7 +39,7 @@ messages:
     tag: RPD_OSPF_NBRUP
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Exchange to Full due to ExchangeDone (event reason: {reasonMessage})'
@@ -55,7 +55,7 @@ messages:
     tag: RPD_OSPF_NBRUP
     values:
       neighbor: ([\w\d:\.]+)
-      interface: ([\w\-\/\.\d]+)
+      interface: ([\w\-\/\:]+)
       area: (\d+\.\d+\.\d+\.\d+)
       reasonMessage: ([\w ]+)
     line: 'OSPF neighbor {neighbor} (realm ospf-v2 {interface} area {area}) state changed from Loading to Full due to LoadDone (event reason: {reasonMessage})'


### PR DESCRIPTION
Breakout ports are of the form `xe-0/0/5:1`, these are not currently
matched.