### PR TITLE
Change the location of the napalm-logs config file in the Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine:3.6
 ARG requirements=""
 ARG version=""
 
-WORKDIR /tmp/napalm-logs
-COPY config.txt .
+RUN mkdir /etc/napalm
+COPY config.txt /etc/napalm/logs
 
 # Install napalm-logs and pre-requisites
 RUN apk add --no-cache \
@@ -21,4 +21,4 @@ RUN for req in $requirements; do \
         pip install $req; \
     done
 
-CMD napalm-logs --config-file config.txt
+CMD napalm-logs --config-file /etc/napalm/logs


### PR DESCRIPTION
So it defaults to the default napalm-logs config file path: https://napalm-logs.com/en/latest/options/index.html#config-file