### PR TITLE
implements #160 - prometheus metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -309,6 +309,7 @@ daemon):
    options/index
    clients/index
    messages/index
+   metrics/index
    authentication/index
    listener/index
    publisher/index

--- a/docs/metrics/index.rst
+++ b/docs/metrics/index.rst
@@ -1,0 +1,17 @@
+.. _metrics:
+
+==================
+Metrics Collection
+==================
+
+Timeseries metrics my be optionally collected and exported from the server.
+This feature is dissabled by default but can be enabled by passing `--enable-metrics`
+when envoking the server.
+
+The metrics offer insight into how the server is processing messages. Each subsystem publishes
+its own set of metrics. These are timeserises data so they are mostly counters of processed
+elements.
+
+We use the Prometheus metrics format and the metrics are exposed by an HTTP server which by default
+run on for 9215. The implementation is fully complient with Prometheus scraping, so you need only
+point your Prometheus server to the exposed metrics to scrape them.

--- a/docs/metrics/index.rst
+++ b/docs/metrics/index.rst
@@ -13,15 +13,82 @@ its own set of metrics. These are timeserises data so they are mostly counters o
 elements.
 
 We use the Prometheus metrics format and the metrics are exposed by an HTTP server which by default
-run on for 9215. The implementation is fully complient with Prometheus scraping, so you need only
+run on port tcp/9443. The implementation is fully complient with Prometheus scraping, so you need only
 point your Prometheus server to the exposed metrics to scrape them.
 
-When using the feature, you need make a directory available which will be used to collect and store
-local metrics from the valious system processes. The server will need rights to write to this
-directory. A directory in ``/tmp`` is fine. Once created you will need to set the
-``prometheus_multiproc_dir`` environment variable which will be read by the server on startup.
+When using the feature, you must make a directory available which will be used to collect and store
+local metrics from the various system processes. The server will need rights to write to this
+directory. By default `/tmp/napalm_logs_metrics` is used. This is configurable with
+`--metrics-dir`. Whatever the value, if the directory does not exist, we attempt to create it
+on startup. Also note than this directory is cleared of all previous metrics entries on each run.
+This means that metric values are not persisted through runs.
 
-.. code-block:: bash
+Here is a listing of the exposed metrics and their meaning:
 
-    $ mkdir /tmp/prom
-    $ export prometheus_multiproc_dir=/tmp/prom
+Listener Process(es)
+--------------------
+
+napalm_logs_listener_logs_ingested
+  Count of ingested log messages. Labels are used to seperate metrics for each Listener process.
+
+napalm_logs_listener_messages_published
+  Count of published messages. The are messages published to the message queue for processing by the Server Process.
+  Labels are used to seperate metrics for each Listener process.
+
+Server Process
+--------------
+
+napalm_logs_server_messages_received
+  Count of messages received from Listener processes.
+
+napalm_logs_server_messages_with_identified_os
+  Count of messages with positive OS identification. Labels are used to seperate metrics for each Device OS.
+
+napalm_logs_server_messages_without_identified_os
+  Count of messages which fail OS identification.
+
+napalm_logs_server_messages_failed_device_queuing
+  Count of messages per device OS that fail to be queued to a proper Device process. Note these are messages that
+  pass OS identification and we know how to route them but fail to be queued. Labels are used to seperate metrics
+  for each Device OS.
+
+napalm_logs_server_messages_device_queued
+  Count of messages sucessfully queued to Device processes. Labels are used to seperate metrics for each Device OS process.
+
+napalm_logs_server_messages_unknown_queued
+  Count of messages which fail OS indentification and thus we don't know how to route them, but the user has instructed
+  the system to queue them "as-is."
+
+Device Process(es)
+------------------
+
+napalm_logs_device_messages_received
+  Count of messages received from the Server process. Labels are used to seperate metrics for each Device OS process.
+
+napalm_logs_device_raw_published_messages
+  Count of raw type published messages. In this case, the message did not match a configured message type but the
+  user has instructed the system to publish the message in a raw format. Labels are used to seperate metrics for
+  each Device OS process.
+
+napalm_logs_device_published_messages
+  Count of published messages. These are messages which are sucessfully converted to an OpenConfig format. Labels
+  are used to seperate metrics for each Device OS process.
+
+napalm_logs_device_oc_object_failed 
+  Counter of failed OpenConfig object generations. These are messages for which the system attempts to map to a
+  known OpenConfig object model but fails. Labels are used to seperate metrics for each Device OS process.
+
+Publisher Process(es)
+---------------------
+
+napalm_logs_publisher_received_messages
+  Count of messages received by the Publisher from Device Process(es). Labels are used to seperate metrics for
+  each Publisher process.
+
+napalm_logs_publisher_whitelist_blacklist_check_fail
+  Count of messages which fail the whitelist/blacklist check. Labels are used to seperate metrics for each
+  Publisher process.
+
+napalm_logs_publisher_messages_published
+  Count of published messages. These are messages which are published for clients to receive (i.e. output of the
+  system). Labels are used to seperate metrics for each Publisher process.

--- a/docs/metrics/index.rst
+++ b/docs/metrics/index.rst
@@ -15,3 +15,13 @@ elements.
 We use the Prometheus metrics format and the metrics are exposed by an HTTP server which by default
 run on for 9215. The implementation is fully complient with Prometheus scraping, so you need only
 point your Prometheus server to the exposed metrics to scrape them.
+
+When using the feature, you need make a directory available which will be used to collect and store
+local metrics from the valious system processes. The server will need rights to write to this
+directory. A directory in ``/tmp`` is fine. Once created you will need to set the
+``prometheus_multiproc_dir`` environment variable which will be read by the server on startup.
+
+.. code-block:: bash
+
+    $ mkdir /tmp/prom
+    $ export prometheus_multiproc_dir=/tmp/prom

--- a/docs/options/index.rst
+++ b/docs/options/index.rst
@@ -127,7 +127,7 @@ Configuration file example:
 The port to listen on for incoming metrics requests. This is the port that
 the Prometheus HTTP server exposes metrics from.
 
-Default: ``9215``
+Default: ``9443``
 
 CLI usgae example:
 
@@ -140,6 +140,26 @@ Configuration file example:
 .. code-block:: yaml
 
   metrics_port: 2022
+
+``metrics-dir``
+-------------
+
+The directory used by the processes for metrics collection. This directory must
+be writable. If the directory does not exist, we attempt to create it.
+
+Default: ``/tmp/napalm_logs_metrics``
+
+CLI usgae example:
+
+.. code-block:: bash
+
+  $ napalm-logs --metrics-dir /tmp/a_new_dir_for_metrics
+
+Configuration file example:
+
+.. code-block:: yaml
+
+  metrics_dir: /tmp/a_new_dir_for_metrics
 
 .. _configuration-options-certificate:
 

--- a/docs/options/index.rst
+++ b/docs/options/index.rst
@@ -76,6 +76,71 @@ Configuration file example:
 
   auth_port: 2022
 
+.. _configuration-options-enable-metrics:
+
+``enable-metrics``
+-------------
+
+Enable metrics collection exposition (Prometheus metrics).
+
+Default: ``false``
+
+CLI usgae example:
+
+.. code-block:: bash
+
+  $ napalm-logs --enable-metrics
+
+Configuration file example:
+
+.. code-block:: yaml
+
+  metrics_enabled: true
+
+.. _configuration-options-metrics-address:
+
+``metrics-address``
+-----------
+
+The IP address to use to listen for all incoming metrics requests. This is the
+address that the Prometheus HTTP server exposes metrics from.
+
+Default: ``0.0.0.0``.
+
+CLI usage example:
+
+.. code-block:: bash
+
+  $ napalm-logs --metrics-address 172.17.17.1
+
+Configuration file example:
+
+.. code-block:: yaml
+
+  metrics_address: 172.17.17.1
+
+.. _configuration-options-metrics-port:
+
+``metrics-port``
+-------------
+
+The port to listen on for incoming metrics requests. This is the port that
+the Prometheus HTTP server exposes metrics from.
+
+Default: ``9215``
+
+CLI usgae example:
+
+.. code-block:: bash
+
+  $ napalm-logs --metrics-port 2022
+
+Configuration file example:
+
+.. code-block:: yaml
+
+  metrics_port: 2022
+
 .. _configuration-options-certificate:
 
 ``certificate``

--- a/napalm_logs/__init__.py
+++ b/napalm_logs/__init__.py
@@ -16,7 +16,7 @@ import os
 os.environ['prometheus_multiproc_dir'] = "/tmp/napalm_logs_metrics"
 
 # Import napalm-logs pkgs
-from napalm_logs.base import NapalmLogs
+from napalm_logs.base import NapalmLogs  # noqa: E402
 
 try:
     __version__ = pkg_resources.get_distribution('napalm-logs').version

--- a/napalm_logs/__init__.py
+++ b/napalm_logs/__init__.py
@@ -6,6 +6,14 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import pkg_resources
+import os
+
+# For metrics collection, the prometheus_client library
+# requires that the env var `prometheus_multiproc_dir`
+# be set before start up. At startup, it doesn't matter
+# what the value is, and we always overwrite it to either
+# the poperly defined default or the user propvided value.
+os.environ['prometheus_multiproc_dir'] = "/tmp/napalm_logs_metrics"
 
 # Import napalm-logs pkgs
 from napalm_logs.base import NapalmLogs

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -21,6 +21,7 @@ import nacl.utils
 import nacl.secret
 import nacl.signing
 import nacl.encoding
+from prometheus_client import start_http_server, CollectorRegistry, multiprocess
 
 # Import napalm-logs pkgs
 import napalm_logs.utils
@@ -48,6 +49,9 @@ class NapalmLogs:
                  publish_port=49017,
                  auth_address='0.0.0.0',
                  auth_port=49018,
+                 metrics_enabled=False,
+                 metrics_address='0.0.0.0',
+                 metrics_port='9215',
                  certificate=None,
                  keyfile=None,
                  disable_security=False,
@@ -80,6 +84,9 @@ class NapalmLogs:
         self.publish_port = publish_port
         self.auth_address = auth_address
         self.auth_port = auth_port
+        self.metrics_enabled = metrics_enabled
+        self.metrics_address = metrics_address
+        self.metrics_port = metrics_port
         self.certificate = certificate
         self.keyfile = keyfile
         self.disable_security = disable_security
@@ -100,6 +107,8 @@ class NapalmLogs:
         self._build_config()
         self._verify_config()
         self._post_preparation()
+        # Start the Prometheus metrics server
+        self._setup_metrics()
         # Private vars
         self.__priv_key = None
         self.__signing_key = None
@@ -114,6 +123,27 @@ class NapalmLogs:
         if exc_type is not None:
             log.error('Exiting due to unhandled exception', exc_info=True)
             self.__raise_clean_exception(exc_type, exc_value, exc_traceback)
+
+    def _setup_metrics(self):
+        """
+        Start metric exposition
+        """
+        if self.metrics_enabled:
+            log.debug("Starting metrics exposition")
+            path = os.environ.get("prometheus_multiproc_dir")
+            if path:
+                log.info("Cleaning metrics collection directory")
+                files = os.listdir(path)
+                for f in files:
+                    if f.endswith(".db"):
+                        os.remove(os.path.join(path, f))
+            registry = CollectorRegistry()
+            multiprocess.MultiProcessCollector(registry)
+            start_http_server(
+                port=self.metrics_port,
+                addr=self.metrics_address,
+                registry=registry
+            )
 
     def _setup_log(self):
         '''

--- a/napalm_logs/base.py
+++ b/napalm_logs/base.py
@@ -21,7 +21,7 @@ import nacl.utils
 import nacl.secret
 import nacl.signing
 import nacl.encoding
-from prometheus_client import start_http_server, CollectorRegistry, multiprocess, core
+from prometheus_client import start_http_server, CollectorRegistry, multiprocess
 
 # Import napalm-logs pkgs
 import napalm_logs.utils
@@ -52,7 +52,7 @@ class NapalmLogs:
                  metrics_enabled=False,
                  metrics_address='0.0.0.0',
                  metrics_port='9215',
-                 metrics_dir=None,
+                 metrics_dir='/tmp/napalm_logs_metrics',
                  certificate=None,
                  keyfile=None,
                  disable_security=False,

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -31,7 +31,8 @@ LOG_FILE = os.path.join(ROOT_DIR, 'var', 'log', 'napalm', 'logs')
 LOG_FILE_CLI_OPTIONS = ('cli', 'screen')
 ZMQ_INTERNAL_HWM = 1000
 METRICS_ADDRESS = '0.0.0.0'
-METRICS_PORT = 9215
+METRICS_PORT = 9443
+METRICS_DIR = "/tmp/napalm_logs_metrics"
 
 # Allowed names for the init files.
 OS_INIT_FILENAMES = (

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -30,6 +30,8 @@ LOG_FORMAT = '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message
 LOG_FILE = os.path.join(ROOT_DIR, 'var', 'log', 'napalm', 'logs')
 LOG_FILE_CLI_OPTIONS = ('cli', 'screen')
 ZMQ_INTERNAL_HWM = 1000
+METRICS_ADDRESS = '0.0.0.0'
+METRICS_PORT = 9215
 
 # Allowed names for the init files.
 OS_INIT_FILENAMES = (

--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -13,6 +13,7 @@ import threading
 # Import third party libs
 import zmq
 import umsgpack
+from prometheus_client import Counter
 
 # Import napalm-logs pkgs
 from napalm_logs.config import LST_IPC_URL
@@ -76,6 +77,17 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         '''
         Listen to messages and publish them.
         '''
+        # counter metrics for messages
+        c_logs_ingested = Counter(
+            'napalm_logs_listener_logs_ingested',
+            'Count of ingested log messages',
+            ['listener_type', 'address', 'port'],
+        )
+        c_messages_published = Counter(
+            'napalm_logs_listener_messages_published',
+            'Count of published messages',
+            ['listener_type', 'address', 'port'],
+        )
         self._setup_ipc()
         log.debug('Using the %s listener', self._listener_type)
         self._setup_listener()
@@ -99,7 +111,9 @@ class NapalmLogsListenerProc(NapalmLogsProc):
             if not log_message:
                 log.info('Empty message received from %s. Not queueing to the server.', log_source)
                 continue
+            c_logs_ingested.labels(listener_type=self._listener_type, address=self.address, port=self.port).inc()
             self.pub.send(umsgpack.packb((log_message, log_source)))
+            c_messages_published.labels(listener_type=self._listener_type, address=self.address, port=self.port).inc()
 
     def stop(self):
         log.info('Stopping the listener process')

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -162,7 +162,8 @@ class NLOptionParser(OptionParser, object):
         self.add_option(
             '--metrics-dir',
             dest='metrics_dir',
-            help=('Directory to store metrics in. Must be writable by the processes. Default: {0}'.format(defaults.METRICS_DIR))
+            help=('Directory to store metrics in. Must be writable by the processes. '
+                  'Default: {0}'.format(defaults.METRICS_DIR))
         )
         self.add_option(
             '--certificate',

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -142,6 +142,24 @@ class NLOptionParser(OptionParser, object):
             help=('Authenticator bind port. Default: {0}'.format(defaults.AUTH_PORT))
         )
         self.add_option(
+            '--enable-metrics',
+            dest='metrics_enabled',
+            action="store_true",
+            default=False,
+            help=('Enable metrics collection and exporting (Prometheus metrics).')
+        )
+        self.add_option(
+            '--metrics-address',
+            dest='metrics_address',
+            help=('Prometheus metrics HTTP server listener address. Default: {0}'.format(defaults.METRICS_ADDRESS))
+        )
+        self.add_option(
+            '--metrics-port',
+            dest='metrics_port',
+            type=int,
+            help=('Prometheus metrics HTTP server listener bind port. Default: {0}'.format(defaults.METRICS_PORT))
+        )
+        self.add_option(
             '--certificate',
             dest='certificate',
             help=('Absolute path to the SSL certificate used for client authentication.')
@@ -258,6 +276,7 @@ class NLOptionParser(OptionParser, object):
                                 format=log_fmt)  # log to filecm
         cert = self.options.certificate or file_cfg.get('certificate')
         disable_security = self.options.disable_security or file_cfg.get('disable_security', False)
+        metrics_enabled = self.options.metrics_enabled or file_cfg.get('metrics_enabled', False)
         if not cert and disable_security is False:
             log.error('certfile must be specified for server-side operations')
             raise ValueError('Please specify a valid SSL certificate.')
@@ -325,6 +344,11 @@ class NLOptionParser(OptionParser, object):
                             defaults.AUTH_ADDRESS,  # noqa
             'auth_port': self.options.auth_port or file_cfg.get('auth_port') or
                          defaults.AUTH_PORT,
+            'metrics_enabled': metrics_enabled,
+            'metrics_address': self.options.metrics_address or file_cfg.get('metrics_address') or
+                               defaults.METRICS_ADDRESS,
+            'metrics_port': self.options.metrics_port or file_cfg.get('metrics_port') or
+                               defaults.METRICS_PORT,
             'certificate': cert,
             'keyfile': self.options.keyfile or file_cfg.get('keyfile'),
             'disable_security': disable_security,

--- a/napalm_logs/scripts/cli.py
+++ b/napalm_logs/scripts/cli.py
@@ -160,6 +160,11 @@ class NLOptionParser(OptionParser, object):
             help=('Prometheus metrics HTTP server listener bind port. Default: {0}'.format(defaults.METRICS_PORT))
         )
         self.add_option(
+            '--metrics-dir',
+            dest='metrics_dir',
+            help=('Directory to store metrics in. Must be writable by the processes. Default: {0}'.format(defaults.METRICS_DIR))
+        )
+        self.add_option(
             '--certificate',
             dest='certificate',
             help=('Absolute path to the SSL certificate used for client authentication.')
@@ -349,6 +354,8 @@ class NLOptionParser(OptionParser, object):
                                defaults.METRICS_ADDRESS,
             'metrics_port': self.options.metrics_port or file_cfg.get('metrics_port') or
                                defaults.METRICS_PORT,
+            'metrics_dir': self.options.metrics_dir or file_cfg.get('metrics_dir') or
+                               defaults.METRICS_DIR,
             'certificate': cert,
             'keyfile': self.options.keyfile or file_cfg.get('keyfile'),
             'disable_security': disable_security,

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -213,9 +213,9 @@ class NapalmLogsServerProc(NapalmLogsProc):
             "Count of messages queued to device processes",
             ['device_os']
         )
-        napalm_logs_server_messages_as_is_queued = Counter(
-            "napalm_logs_server_messages_as_is_queued",
-            "Count of messages queued as is"
+        napalm_logs_server_messages_unknown_queued = Counter(
+            "napalm_logs_server_messages_unknown_queued",
+            "Count of messages queued as unknown"
         )
         self._setup_ipc()
         # Start suicide polling thread
@@ -275,7 +275,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
                     'model_name': 'unknown'
                 }
                 self.publisher_pub.send(umsgpack.packb(to_publish))
-                napalm_logs_server_messages_as_is_queued.inc()
+                napalm_logs_server_messages_unknown_queued.inc()
                 napalm_logs_server_messages_without_identified_os.inc()
 
             elif not dev_os and not self.opts['_server_send_unknown']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyzmq
 pyyaml
 pynacl
 u-msgpack-python
+prometheus_client


### PR DESCRIPTION
I have taken a stab at #160. Here is a list of the current metrics:

### listener
- napalm_logs_listener_logs_ingested - Count of ingested log messages (per listener via labels)
- napalm_logs_listener_messages_published - Count of published messages (per listener via labels)

### server
- napalm_logs_server_messages_received - Count of messages received from listener processes
- napalm_logs_server_messages_with_identified_os - Count of messages with positive os identification (per device os via labels)
- napalm_logs_server_messages_without_identified_os - Count of messages with negative os identification
- napalm_logs_server_messages_failed_device_queuing - Count of messages per device os that fail to be queued to a device process (per device os via labels)
- napalm_logs_server_messages_device_queued - Count of messages queued to device processes (per device os via labels)
- napalm_logs_server_messages_as_is_queued - Count of messages queued as is

### device
- napalm_logs_device_messages_received - Count of messages received by the device process (per device os via labels)
- napalm_logs_device_raw_published_messages - Count of raw type published messages (per device os via labels)
- napalm_logs_device_published_messages - Count of published messages (per device os via labels)
- napalm_logs_device_oc_object_failed - Counter of failed OpenConfig object generations (per device os via labels)

### publisher
- napalm_logs_publisher_received_messages - Count of messages received by the publisher (per publisher via labels)
- napalm_logs_publisher_whitelist_blacklist_check_fail - Count of messages which fail the whitelist/blacklist check (per publisher via labels) - **this one I am not really sure of the correct meaning for**
- napalm_logs_publisher_messages_published - Count of published messages (per publisher via labels)

Because the system is by nature multiprocessed, we have to run the metrics collector in so-called "multiprocess mode," which comes with a few limitations/considerations. Help texts are not preserved in the exported metrics. Also, we have to provide a directory that the processes can write to which is used to dump metrics for sharing back to the main collector. That directory must be passed as the `prometheus_multiproc_dir` env var. This is mentioned in the docs.

Let me know what you think.