### PR TITLE
Adapt syslog message format for messages with synchronised clock on IOS

### DIFF
--- a/napalm_logs/config/ios/init.yml
+++ b/napalm_logs/config/ios/init.yml
@@ -6,7 +6,7 @@ prefixes:
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: \*?(\w+\s*\d+)
+      date: \*?(\w+\s+\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d\d\d)
       tag: ([\w-]+)
@@ -17,7 +17,7 @@ prefixes:
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: \*?(\w+\s*\d+)
+      date: \*?(\w+\s+\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d+)
       tag: ([\w-]+)

--- a/napalm_logs/config/ios/init.yml
+++ b/napalm_logs/config/ios/init.yml
@@ -6,19 +6,19 @@ prefixes:
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: (\w+\s?\d+)
+      date: \*?(\w+\s?\W?\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d\d\d)
       tag: ([\w-]+)
       # some messages contain a process number (eg. OSPF related messages)
       processId: (\d+)
-    line: '{messageId}: {host}: *{date} {time}.{milliseconds}: %{tag}: Process {processId}, '
+    line: '{messageId}: {host}: {date} {time}.{milliseconds}: %{tag}: Process {processId}, '
   - time_format: "%b %d %H:%M:%S"
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: (\w+\s?\d+)
+      date: \*?(\w+\s?\W?\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d+)
       tag: ([\w-]+)
-    line: '{messageId}: {host}: *{date} {time}.{milliseconds}: %{tag}: '
+    line: '{messageId}: {host}: {date} {time}.{milliseconds}: %{tag}: '

--- a/napalm_logs/config/ios/init.yml
+++ b/napalm_logs/config/ios/init.yml
@@ -6,7 +6,7 @@ prefixes:
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: \*?(\w+\s?\W?\d+)
+      date: \*?(\w+\s*\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d\d\d)
       tag: ([\w-]+)
@@ -17,7 +17,7 @@ prefixes:
     values:
       messageId: (\d+)
       host: ([^ ]+)
-      date: \*?(\w+\s?\W?\d+)
+      date: \*?(\w+\s*\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d+)
       tag: ([\w-]+)

--- a/tests/config/ios/INTERFACE_DOWN/time_synchronized/syslog.msg
+++ b/tests/config/ios/INTERFACE_DOWN/time_synchronized/syslog.msg
@@ -1,0 +1,1 @@
+<189>117: NetAuto_CSRv-03: May  9 12:49:27.098: %LINK-5-CHANGED: Interface GigabitEthernet2, changed state to administratively down

--- a/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
@@ -1,0 +1,33 @@
+{
+	"yang_message": {
+		"interfaces": {
+			"interface": {
+				"GigabitEthernet2": {
+					"state": {
+						"admin_status": "DOWN"
+					}
+				}
+			}
+		}
+	},
+	"message_details": {
+		"facility": 23,
+		"time": "08:30:56",
+		"pri": "189",
+		"host": "router1",
+		"tag": "LINK-5-CHANGED",
+		"messageId": "521",
+		"date": "Nov 14",
+		"message": "Interface GigabitEthernet2, changed state to administratively down",
+		"milliseconds": "699",
+		"severity": 5
+	},
+	"host": "router1",
+	"timestamp": 1510648256,
+	"error": "INTERFACE_DOWN",
+	"ip": "127.0.0.1",
+	"facility": 23,
+	"os": "ios",
+	"yang_model": "openconfig-interfaces",
+	"severity": 5
+}

--- a/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
@@ -1,33 +1,33 @@
 {
-	"yang_message": {
-		"interfaces": {
-			"interface": {
-				"GigabitEthernet2": {
-					"state": {
-						"admin_status": "DOWN"
-					}
-				}
-			}
-		}
-	},
-	"message_details": {
-		"facility": 23,
-		"time": "08:30:56",
-		"pri": "189",
-		"host": "router1",
-		"tag": "LINK-5-CHANGED",
-		"messageId": "521",
-		"date": "Nov 14",
-		"message": "Interface GigabitEthernet2, changed state to administratively down",
-		"milliseconds": "699",
-		"severity": 5
-	},
-	"host": "router1",
-	"timestamp": 1510648256,
-	"error": "INTERFACE_DOWN",
-	"ip": "127.0.0.1",
-	"facility": 23,
-	"os": "ios",
-	"yang_model": "openconfig-interfaces",
-	"severity": 5
+  "yang_message": {
+    "interfaces": {
+      "interface": {
+        "GigabitEthernet2": {
+          "state": {
+            "admin_status": "DOWN"
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "severity": 5,
+    "facility": 23,
+    "messageId": "117",
+    "pri": "189",
+    "host": "NetAuto_CSRv-03",
+    "tag": "LINK-5-CHANGED",
+    "time": "12:49:27",
+    "date": "May 9",
+    "message": "Interface GigabitEthernet2, changed state to administratively down",
+    "milliseconds": "098"
+  },
+  "facility": 23,
+  "ip": "127.0.0.1",
+  "error": "INTERFACE_DOWN",
+  "host": "NetAuto_CSRv-03",
+  "yang_model": "openconfig-interfaces",
+  "timestamp": 1525870167,
+  "os": "ios",
+  "severity": 5
 }

--- a/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
@@ -18,7 +18,7 @@
     "host": "NetAuto_CSRv-03",
     "tag": "LINK-5-CHANGED",
     "time": "12:49:27",
-    "date": "May 9",
+    "date": "May  9",
     "message": "Interface GigabitEthernet2, changed state to administratively down",
     "milliseconds": "098"
   },


### PR DESCRIPTION
Pull request for issue [237](https://github.com/napalm-automation/napalm-logs/issues/237)

If the clock is synchronised, there is no asterisk (*) in the message.
Hostname can now also consist  -