### PR TITLE
Allow message to match on multiple OS

### DIFF
--- a/napalm_logs/listener/kafka.py
+++ b/napalm_logs/listener/kafka.py
@@ -14,7 +14,7 @@ import logging
 try:
     import kafka
     HAS_KAFKA = True
-except ImportError as err:
+except ImportError:
     HAS_KAFKA = False
 
 # Import napalm-logs pkgs

--- a/napalm_logs/listener/zeromq.py
+++ b/napalm_logs/listener/zeromq.py
@@ -13,7 +13,7 @@ import logging
 try:
     import zmq
     HAS_ZMQ = True
-except ImportError as err:
+except ImportError:
     HAS_ZMQ = False
 
 # Import napalm-logs pkgs

--- a/napalm_logs/transport/kafka.py
+++ b/napalm_logs/transport/kafka.py
@@ -12,7 +12,7 @@ import logging
 try:
     import kafka
     HAS_KAFKA = True
-except ImportError as err:
+except ImportError:
     HAS_KAFKA = False
 
 # Import napalm-logs pkgs

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,7 @@ def startup_proc():
     NL_BASE = NapalmLogs(disable_security=True,
                          address=NAPALM_LOGS_TEST_ADDR,
                          port=NAPALM_LOGS_TEST_PORT,
-                         publisher=[{'zmq': {'send_raw': True, 'send_unknown': True}}],
+                         publisher=[{'zmq': {'send_unknown': True}}],
                          listener=[{'udp': {}}],
                          publish_address=NAPALM_LOGS_TEST_PUB_ADDR,
                          publish_port=NAPALM_LOGS_TEST_PUB_PORT,


### PR DESCRIPTION
This fixes #242

Currently when a matching OS is found we do not check remaining OS. This
mean that if 2 OS have message prefixes that match each other's logs
then you cannot be sure that the message will be forwarded onto the
correct `device` process.

I have updated so the message is now forwarded onto all matching os, not
just the first match.

To allow the tests to work correctly I have removed `'send_raw': True`
from the config test.