### PR TITLE
Timezone added to IOS

### DIFF
--- a/napalm_logs/config/ios/init.yml
+++ b/napalm_logs/config/ios/init.yml
@@ -9,10 +9,11 @@ prefixes:
       date: \*?(\w+\s+\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d\d\d)
+      timeZone: \s?(\w+)?
       tag: ([\w-]+)
       # some messages contain a process number (eg. OSPF related messages)
       processId: (\d+)
-    line: '{messageId}: {host}: {date} {time}.{milliseconds}: %{tag}: Process {processId}, '
+    line: '{messageId}: {host}: {date} {time}.{milliseconds}{timeZone}: %{tag}: Process {processId}, '
   - time_format: "%b %d %H:%M:%S"
     values:
       messageId: (\d+)
@@ -20,5 +21,6 @@ prefixes:
       date: \*?(\w+\s+\d+)
       time: (\d\d:\d\d:\d\d)
       milliseconds: (\d+)
+      timeZone: \s?(\w+)?
       tag: ([\w-]+)
-    line: '{messageId}: {host}: {date} {time}.{milliseconds}: %{tag}: '
+    line: '{messageId}: {host}: {date} {time}.{milliseconds}{timeZone}: %{tag}: '

--- a/tests/config/ios/INTERFACE_DOWN/default/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/default/yang.json
@@ -17,6 +17,7 @@
     "host": "router1",
     "tag": "LINK-5-CHANGED",
     "time": "08:30:56",
+    "timeZone": null,
     "date": "Nov 14",
     "messageId": "521",
     "milliseconds": "699",

--- a/tests/config/ios/INTERFACE_DOWN/message_with_timezone/syslog.msg
+++ b/tests/config/ios/INTERFACE_DOWN/message_with_timezone/syslog.msg
@@ -1,0 +1,1 @@
+<189>1179: NetAuto_CSRv-03: May 31 15:25:53.743 MEST: %LINK-5-CHANGED: Interface GigabitEthernet2, changed state to administratively down from 10.83.75.201

--- a/tests/config/ios/INTERFACE_DOWN/message_with_timezone/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/message_with_timezone/yang.json
@@ -1,0 +1,34 @@
+{
+  "yang_message": {
+    "interfaces": {
+      "interface": {
+        "GigabitEthernet2": {
+          "state": {
+            "admin_status": "DOWN"
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "severity": 5,
+    "facility": 23,
+    "time": "15:25:53",
+    "pri": "189",
+    "host": "NetAuto_CSRv-03",
+    "tag": "LINK-5-CHANGED",
+    "messageId": "1179",
+    "date": "May 31",
+    "timeZone": "MEST",
+    "message": "Interface GigabitEthernet2, changed state to administratively down from 10.83.75.201",
+    "milliseconds": "743"
+  },
+  "facility": 23,
+  "ip": "127.0.0.1",
+  "error": "INTERFACE_DOWN",
+  "host": "NetAuto_CSRv-03",
+  "yang_model": "openconfig-interfaces",
+  "timestamp": 1527780353,
+  "os": "ios",
+  "severity": 5
+}

--- a/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
+++ b/tests/config/ios/INTERFACE_DOWN/time_synchronized/yang.json
@@ -18,6 +18,7 @@
     "host": "NetAuto_CSRv-03",
     "tag": "LINK-5-CHANGED",
     "time": "12:49:27",
+    "timeZone": null,
     "date": "May  9",
     "message": "Interface GigabitEthernet2, changed state to administratively down",
     "milliseconds": "098"

--- a/tests/config/ios/OSPF_NEIGHBOR_DOWN/init_to_down/yang.json
+++ b/tests/config/ios/OSPF_NEIGHBOR_DOWN/init_to_down/yang.json
@@ -41,6 +41,7 @@
   "message_details": {
     "date": "Mar 15",
     "time": "10:05:53",
+    "timeZone": null,
     "host": "router1",
     "processId": "1",
     "tag": "OSPF-5-ADJCHG",

--- a/tests/config/ios/OSPF_NEIGHBOR_UP/loading_to_full/yang.json
+++ b/tests/config/ios/OSPF_NEIGHBOR_UP/loading_to_full/yang.json
@@ -39,6 +39,7 @@
   "message_details": {
     "date": "Mar 15",
     "time": "10:05:53",
+    "timeZone": null,
     "host": "router1",
     "processId": "1",
     "tag": "OSPF-5-ADJCHG",

--- a/tests/config/ios/USER_EXIT_CONFIG_MODE/bootstrap/yang.json
+++ b/tests/config/ios/USER_EXIT_CONFIG_MODE/bootstrap/yang.json
@@ -20,6 +20,7 @@
     "host": "test-ztp",
     "tag": "SYS-5-CONFIG_I",
     "time": "15:49:32",
+    "timeZone": null,
     "date": "May 23",
     "message": "Configured from tftp://10.83.21.224//cisco-bootstrap by console",
     "milliseconds": "302"

--- a/tests/config/ios/USER_EXIT_CONFIG_MODE/default/yang.json
+++ b/tests/config/ios/USER_EXIT_CONFIG_MODE/default/yang.json
@@ -20,6 +20,7 @@
     "host": "test-ztp",
     "tag": "SYS-5-CONFIG_I",
     "time": "13:56:15",
+    "timeZone": null,
     "date": "May 23",
     "message": "Configured from console by admin on vty0 (10.31.0.24)",
     "milliseconds": "055"

--- a/tests/config/ios/USER_EXIT_CONFIG_MODE/message_with_timezone/syslog.msg
+++ b/tests/config/ios/USER_EXIT_CONFIG_MODE/message_with_timezone/syslog.msg
@@ -1,0 +1,1 @@
+<189>27: test-ztp: May 31 15:54:54.567 MEST: %SYS-5-CONFIG_I: Configured from console by admin on console

--- a/tests/config/ios/USER_EXIT_CONFIG_MODE/message_with_timezone/yang.json
+++ b/tests/config/ios/USER_EXIT_CONFIG_MODE/message_with_timezone/yang.json
@@ -1,0 +1,36 @@
+{
+  "yang_message": {
+    "users": {
+      "user": {
+        "admin": {
+          "action": {
+            "vty": "console",
+            "exit_config_mode": true,
+            "from": "console"
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "severity": 5,
+    "facility": 23,
+    "time": "15:54:54",
+    "pri": "189",
+    "host": "test-ztp",
+    "tag": "SYS-5-CONFIG_I",
+    "messageId": "27",
+    "date": "May 31",
+    "timeZone": "MEST",
+    "message": "Configured from console by admin on console",
+    "milliseconds": "567"
+  },
+  "facility": 23,
+  "ip": "127.0.0.1",
+  "error": "USER_EXIT_CONFIG_MODE",
+  "host": "test-ztp",
+  "yang_model": "NO_MODEL",
+  "timestamp": 1527782094,
+  "os": "ios",
+  "severity": 5
+}


### PR DESCRIPTION
If the show-timezone is set for timestamps on IOS the log-message appears the following:
`<189>27: test-ztp: May 31 15:54:54.567 MEST: %SYS-5-CONFIG_I: Configured from console by admin on console`

The timezone could be e.g. `UTC`, `MET` or `MEST`.