### PR TITLE
Return message even if no OS has matched

### DIFF
--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -193,6 +193,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
                 log.debug('No match found for %s', dev_os)
         if not ret:
             log.debug('Not matched any OS')
+            ret.append((None, msg_dict))
         return ret
 
     def start(self):


### PR DESCRIPTION
Hey,

This commit fixes https://github.com/napalm-automation/napalm-logs/issues/252 (or at least it tries to :smile: ) and might
also help keeping track of messages that do not match any OS in general.
I think send_unknown was broken for OSes that did not match.