### PR TITLE
Allow SO_REUSEPORT on TCP and UDP listeners

### DIFF
--- a/docs/listener/tcp.rst
+++ b/docs/listener/tcp.rst
@@ -21,6 +21,19 @@ Example:
     tcp:
       buffer_size: 2048
 
+``reuse_port``: ``false``
+-------------------------
+
+Enable or disable SO_REUSEPORT on listener's socket.
+
+Example:
+
+.. code-block:: yaml
+
+  listener:
+    udp:
+      reuse_port: true
+
 ``socket_timeout``: ``60``
 --------------------------
 

--- a/docs/listener/udp.rst
+++ b/docs/listener/udp.rst
@@ -20,3 +20,16 @@ Example:
   listener:
     udp:
       buffer_size: 2048
+
+``reuse_port``: ``false``
+-------------------------
+
+Enable or disable SO_REUSEPORT on listener's socket.
+
+Example:
+
+.. code-block:: yaml
+
+  listener:
+    udp:
+      reuse_port: true

--- a/napalm_logs/config/__init__.py
+++ b/napalm_logs/config/__init__.py
@@ -99,6 +99,7 @@ VALID_CONFIG = {
 
 # listener
 BUFFER_SIZE = 1024
+REUSE_PORT = False
 TIMEOUT = 60
 
 # device


### PR DESCRIPTION
In some setups, one may want to silently plug to a port already used by an application listening for syslogs. This PR adds an option on TCP and UDP listeners to allow SO_REUSEPORT.