### PR TITLE
Update BGP_NEIGHBOR_STATE_CHANGED.yml

### DIFF
--- a/napalm_logs/config/junos/BGP_NEIGHBOR_STATE_CHANGED.yml
+++ b/napalm_logs/config/junos/BGP_NEIGHBOR_STATE_CHANGED.yml
@@ -12,7 +12,7 @@ messages:
       event: (\w+)
       oldState|bgp_state_convert: (\w+)
       newState|bgp_state_convert: (\w+)
-    line: 'BGP peer {peer} ({peeringType} AS {asn}) changed state from {oldState} to {newState} (event {event}) (instance master)'
+    line: 'BGP peer {peer} ({peeringType} AS {asn}) changed state from {oldState} to {newState} (event {event})'
     model: openconfig-bgp
     mapping:
       variables:


### PR DESCRIPTION
Removed 'instance master' qualification from line to match all instances where BGP neighbors change state.

This is my proposed fix for https://github.com/napalm-automation/napalm-logs/issues/270
