### PR TITLE
Add eos AGENT_INITIALIZED message

### DIFF
--- a/napalm_logs/config/eos/AGENT_INITIALIZED.yml
+++ b/napalm_logs/config/eos/AGENT_INITIALIZED.yml
@@ -1,0 +1,15 @@
+messages:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: AGENT_INITIALIZED
+    tag: AGENT-6-INITIALIZED
+    values:
+      agent: ([a-zA-Z]+)
+      pid|str: (\d+)
+    line: "Agent '{agent}' initialized; pid={pid}"
+    model: NO_MODEL
+    mapping:
+      variables:
+        system//processes//process//{pid}//state//name: agent
+      static:
+        system//processes//process//{pid}//state//up-time: 0

--- a/napalm_logs/utils/__init__.py
+++ b/napalm_logs/utils/__init__.py
@@ -27,6 +27,7 @@ from nacl.exceptions import BadSignatureError
 
 # Import napalm-logs pkgs
 import napalm_logs.config as defaults
+import napalm_logs.ext.six as six
 from napalm_logs.exceptions import ClientConnectException
 from napalm_logs.exceptions import CryptoException
 from napalm_logs.exceptions import BadSignatureException
@@ -259,10 +260,7 @@ def setval(key, val, dict_=None, delim=defaults.DEFAULT_DELIM):
     prev_hier = dict_
     dict_hier = key.split(delim)
     for each in dict_hier[:-1]:
-        try:
-            idx = int(each)  # noqa
-        except ValueError:
-            # not int
+        if isinstance(each, six.string_type):
             if each not in prev_hier:
                 prev_hier[each] = {}
             prev_hier = prev_hier[each]
@@ -284,9 +282,7 @@ def traverse(data, key, delim=defaults.DEFAULT_DELIM):
     '''
     for each in key.split(delim):
         if isinstance(data, list):
-            try:
-                idx = int(each)
-            except ValueError:
+            if isinstance(each, six.string_type):
                 embed_match = False
                 # Index was not numeric, lets look at any embedded dicts
                 for embedded in (x for x in data if isinstance(x, dict)):
@@ -301,7 +297,7 @@ def traverse(data, key, delim=defaults.DEFAULT_DELIM):
                     return None
             else:
                 try:
-                    data = data[idx]
+                    data = data[int(each)]
                 except IndexError:
                     return None
         else:

--- a/tests/config/eos/AGENT_INITIALIZED/default/syslog.msg
+++ b/tests/config/eos/AGENT_INITIALIZED/default/syslog.msg
@@ -1,0 +1,1 @@
+<166>Oct 18 14:39:03 edge01.bru01 Rib: %AGENT-6-INITIALIZED: Agent 'Rib' initialized; pid=7104

--- a/tests/config/eos/AGENT_INITIALIZED/default/yang.json
+++ b/tests/config/eos/AGENT_INITIALIZED/default/yang.json
@@ -1,0 +1,35 @@
+{
+  "yang_message": {
+    "system": {
+      "processes": {
+        "process": {
+          "7104": {
+            "state": {
+              "up-time": 0,
+              "name": "Rib"
+            }
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "severity": 6,
+    "facility": 20,
+    "pri": "166",
+    "processName": "Rib",
+    "host": "edge01.bru01",
+    "tag": "AGENT-6-INITIALIZED",
+    "time": "14:39:03",
+    "date": "Oct 18",
+    "message": ": Agent 'Rib' initialized; pid=7104"
+  },
+  "facility": 20,
+  "ip": "127.0.0.1",
+  "error": "AGENT_INITIALIZED",
+  "host": "edge01.bru01",
+  "yang_model": "NO_MODEL",
+  "timestamp": 1539873543,
+  "os": "eos",
+  "severity": 6
+}


### PR DESCRIPTION
To represent this message I am using:

```
system//processes//process//{pid}//state
```

Currently if you use a number as a key redering the object fails as
it tries to use a list, therefore I have updated `setval` and `traverse`
functions to check for a string to see if we should have a dict or a
list.