### PR TITLE
Return original log if no OS has matched

### DIFF
--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -209,7 +209,8 @@ class NapalmLogsServerProc(NapalmLogsProc):
             else:
                 log.debug('No match found for %s', dev_os)
         if not ret:
-            log.debug('Not matched any OS')
+            log.debug('Not matched any OS, returning original log')
+            msg_dict = {'message': msg}
             ret.append((None, msg_dict))
         return ret
 


### PR DESCRIPTION
This PR restores the behavior described in [the documentation](http://napalm-logs.com/en/latest/messages/UNKNOWN.html). Currently, msg_dict equals to False so we don't get the original log when listening for unknown messages.