### PR TITLE
parse JunOS FPC logs

### DIFF
--- a/napalm_logs/config/junos/init.yml
+++ b/napalm_logs/config/junos/init.yml
@@ -25,3 +25,14 @@ prefixes:
       # Most log lines have a process ID, however some do not
       processId: (\d+)
     line: '{date} {time} {hostPrefix}{host} {tag}[{processId}]:'
+  - time_format: "%b %d %H:%M:%S"
+    values:
+      date: (\w+\s+\d+)
+      time: (\d\d:\d\d:\d\d)
+      hostPrefix: (re\d.)?
+      host: ([^ ]+)
+      fpcId: (\d+)
+      tag: (\w+)
+      # Some logs have data which can be inside brackets or parenthesis
+      additionalData: (?:(?:\[|\()(.+)(?:\]|\)))?
+    line: '{date} {time} {hostPrefix}{host} fpc{fpcId} {tag}{additionalData}:'


### PR DESCRIPTION
On some Juniper devices (only QFX5k have been tested), some logs coming
from the fpc do not match the classic format. Note that this commit will
not match all messages since some of them have no real proper formatting
and it is for example impossible to extract any tag from them.