### PR TITLE
Remove special character from value key

### DIFF
--- a/napalm_logs/config/opengear/RXDATA.yml
+++ b/napalm_logs/config/opengear/RXDATA.yml
@@ -4,8 +4,8 @@ messages:
   - error: RXDATA
     tag: RXDATA
     values:
-      console_message: (.*)
-    line: '{console_message}'
+      consoleMessage: (.*)
+    line: '{consoleMessage}'
     model: NO_MODEL
     mapping:
       static:


### PR DESCRIPTION
@gtcat I am updating the `RXDATA` value key `console_message` as we should not use special characters in the value keys:

```
2019-01-10 12:38:26,603,604 [napalm_logs.device][DEBUG   ] Starting process for opengear
Traceback (most recent call last):
  File "scripts/cli.py", line 417, in <module>
    napalm_logs_engine()
  File "scripts/cli.py", line 406, in napalm_logs_engine
    nl.start_engine()
  File "/home/luke/git/napalm-logs/napalm_logs/base.py", line 651, in start_engine
    device_config))
  File "/home/luke/git/napalm-logs/napalm_logs/base.py", line 606, in _start_dev_proc
    device_config)
  File "/home/luke/git/napalm-logs/napalm_logs/device.py", line 46, in __init__
    self._compile_messages()
  File "/home/luke/git/napalm-logs/napalm_logs/device.py", line 129, in _compile_messages
    'line': re.compile(escaped.format(**values)),
KeyError: 'console\\_message'
```