### PR TITLE
Add new junos log for NH: hold packet out failed

### DIFF
--- a/napalm_logs/config/junos/NH_HOLD_PACKET.yml
+++ b/napalm_logs/config/junos/NH_HOLD_PACKET.yml
@@ -1,0 +1,13 @@
+messages:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: NH_HOLD_PACKET
+    tag: NH
+    values:
+      id: (\d+)
+    line: 'hold packet out failed, ID {id}'
+    model: NO_MODEL
+    mapping:
+      variables:
+        nh//hold_packet//id: id
+      static: {}

--- a/tests/config/junos/NH_HOLD_PACKET/default/syslog.msg
+++ b/tests/config/junos/NH_HOLD_PACKET/default/syslog.msg
@@ -1,0 +1,1 @@
+<7>Jan 15 08:18:57  re0.vmx01 fpc1 NH: hold packet out failed, ID 6891

--- a/tests/config/junos/NH_HOLD_PACKET/default/yang.json
+++ b/tests/config/junos/NH_HOLD_PACKET/default/yang.json
@@ -1,0 +1,30 @@
+{
+  "ip": "127.0.0.1",
+  "host": "vmx01",
+  "yang_message": {
+    "nh": {
+      "hold_packet": {
+        "id": "6891"
+      }
+    }
+  },
+  "message_details": {
+    "facility": 0,
+    "hostPrefix": "re0.",
+    "pri": "7",
+    "host": "vmx01",
+    "tag": "NH",
+    "date": "Jan 15",
+    "message": "hold packet out failed, ID 6891",
+    "additionalData": null,
+    "severity": 7,
+    "fpcId": "1",
+    "time": "08:18:57"
+  },
+  "error": "NH_HOLD_PACKET",
+  "timestamp": 1547540337,
+  "facility": 0,
+  "os": "junos",
+  "yang_model": "NO_MODEL",
+  "severity": 7
+}


### PR DESCRIPTION
This error is seen when the routing engine is unable to insert all
routes into the forwarding table.