### PR TITLE
Add nxos BPDU guard error:

### DIFF
--- a/napalm_logs/config/nxos/STP_BLOCK_BPDUGUARD.yml
+++ b/napalm_logs/config/nxos/STP_BLOCK_BPDUGUARD.yml
@@ -1,0 +1,12 @@
+messages:
+  - error: STP_BLOCK_BPDUGUARD
+    tag: STP-2-BLOCK_BPDUGUARD
+    values:
+      interface: (\w+[\.\-\d\/\w+]+)
+    line: 'Received BPDU on port {interface} with BPDU Guard enabled. Disabling port.'
+    model: openconfig-interfaces
+    mapping:
+      variables: {}
+      static:
+        interfaces//interface//{interface}//state//change_reason: BPDUGuard
+        interfaces//interface//{interface}//state//admin_status: DOWN

--- a/tests/config/nxos/STP_BLOCK_BPDUGUARD/default/syslog.msg
+++ b/tests/config/nxos/STP_BLOCK_BPDUGUARD/default/syslog.msg
@@ -1,0 +1,1 @@
+<189>2019 Jan 16 04:40:19 switch01 %STP-2-BLOCK_BPDUGUARD: Received BPDU on port Ethernet1/43 with BPDU Guard enabled. Disabling port.

--- a/tests/config/nxos/STP_BLOCK_BPDUGUARD/default/yang.json
+++ b/tests/config/nxos/STP_BLOCK_BPDUGUARD/default/yang.json
@@ -1,0 +1,32 @@
+{
+  "ip": "127.0.0.1",
+  "host": "switch01",
+  "yang_message": {
+    "interfaces": {
+      "interface": {
+        "Ethernet1/43": {
+          "state": {
+            "admin_status": "DOWN",
+            "change_reason": "BPDUGuard"
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "host": "switch01",
+    "tag": "STP-2-BLOCK_BPDUGUARD",
+    "severity": 5,
+    "facility": 23,
+    "date": "2019 Jan 16",
+    "message": "Received BPDU on port Ethernet1/43 with BPDU Guard enabled. Disabling port.",
+    "time": "04:40:19",
+    "pri": "189"
+  },
+  "error": "STP_BLOCK_BPDUGUARD",
+  "timestamp": 1547613619,
+  "facility": 23,
+  "os": "nxos",
+  "yang_model": "openconfig-interfaces",
+  "severity": 5
+}


### PR DESCRIPTION
```
<189>2019 Jan 16 04:40:19 switch01 %STP-2-BLOCK_BPDUGUARD: Received BPDU
on port Ethernet1/43 with BPDU Guard enabled. Disabling port.
```
```
{
  "ip": "127.0.0.1",
  "host": "switch01",
  "yang_message": {
    "interfaces": {
      "interface": {
        "Ethernet1/43": {
          "state": {
            "admin_status": "DOWN",
            "change_reason": "BPDUGuard"
          }
        }
      }
    }
  },
  "message_details": {
    "host": "switch01",
    "tag": "STP-2-BLOCK_BPDUGUARD",
    "severity": 5,
    "facility": 23,
    "date": "2019 Jan 16",
    "message": "Received BPDU on port Ethernet1/43 with BPDU Guard
enabled. Disabling port.",
    "time": "04:40:19",
    "pri": "189"
  },
  "error": "STP_BLOCK_BPDUGUARD",
  "timestamp": 1547613619,
  "facility": 23,
  "os": "nxos",
  "yang_model": "openconfig-interfaces",
  "severity": 5
}
```