### PR TITLE
parse JunOS NAT logs with "0x0"

### DIFF
--- a/napalm_logs/config/junos/NAT_SESSION_CLOSED.yml
+++ b/napalm_logs/config/junos/NAT_SESSION_CLOSED.yml
@@ -37,3 +37,37 @@ messages:
         security//flow//closed//protocol_id: protocolId
         security//flow//closed//misc_data: miscData
       static: {}
+  - error: NAT_SESSION_CLOSED
+    tag: RT_FLOW_SESSION_CLOSE
+    values:
+      reason: ([^:]+)
+      sourceAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      sourcePort: (\d+)
+      destinationAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      destinationPort: (\d+)
+      serviceName: ([\w+-?]+)
+      natSourceAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      natSourcePort: (\d+)
+      natDestinationAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      natDestinationPort: (\d+)
+      srcNatRuleName: (?:source rule ([^ ]+)|N\/A N\/A)
+      protocolId: (\d+)
+      miscData: (.*)
+    line: 'session closed {reason}: {sourceAddress}/{sourcePort}->{destinationAddress}/{destinationPort} 0x0 {serviceName} {natSourceAddress}/{natSourcePort}->{natDestinationAddress}/{natDestinationPort} 0x0 {srcNatRuleName} N/A N/A {protocolId} {miscData}'
+    model: NO_MODEL
+    mapping:
+      variables:
+        security//flow//closed//reason: reason
+        security//flow//closed//source_address: sourceAddress
+        security//flow//closed//source_port: sourcePort
+        security//flow//closed//destination_address: destinationAddress
+        security//flow//closed//destination_port: destinationPort
+        security//flow//closed//service_name: serviceName
+        security//flow//closed//nat_source_address: natSourceAddress
+        security//flow//closed//nat_source_port: natSourcePort
+        security//flow//closed//nat_destination_address: natDestinationAddress
+        security//flow//closed//nat_destination_port: natDestinationPort
+        security//flow//closed//src_nat_rule_name: srcNatRuleName
+        security//flow//closed//protocol_id: protocolId
+        security//flow//closed//misc_data: miscData
+      static: {}

--- a/napalm_logs/config/junos/NAT_SESSION_CREATED.yml
+++ b/napalm_logs/config/junos/NAT_SESSION_CREATED.yml
@@ -35,3 +35,35 @@ messages:
         security//flow//created//protocol_id: protocolId
         security//flow//created//misc_data: miscData
       static: {}
+  - error: NAT_SESSION_CREATED
+    tag: RT_FLOW_SESSION_CREATE
+    values:
+      sourceAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      sourcePort: (\d+)
+      destinationAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      destinationPort: (\d+)
+      serviceName: ([\w+-?]+)
+      natSourceAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      natSourcePort: (\d+)
+      natDestinationAddress: ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+      natDestinationPort: (\d+)
+      srcNatRuleName: (?:source rule ([^ ]+)|N\/A N\/A)
+      protocolId: (\d+)
+      miscData: (.*)
+    line: 'session created {sourceAddress}/{sourcePort}->{destinationAddress}/{destinationPort} 0x0 {serviceName} {natSourceAddress}/{natSourcePort}->{natDestinationAddress}/{natDestinationPort} 0x0 {srcNatRuleName} N/A N/A {protocolId} {miscData}'
+    model: NO_MODEL
+    mapping:
+      variables:
+        security//flow//created//source_address: sourceAddress
+        security//flow//created//source_port: sourcePort
+        security//flow//created//destination_address: destinationAddress
+        security//flow//created//destination_port: destinationPort
+        security//flow//created//service_name: serviceName
+        security//flow//created//nat_source_address: natSourceAddress
+        security//flow//created//nat_source_port: natSourcePort
+        security//flow//created//nat_destination_address: natDestinationAddress
+        security//flow//created//nat_destination_port: natDestinationPort
+        security//flow//created//src_nat_rule_name: srcNatRuleName
+        security//flow//created//protocol_id: protocolId
+        security//flow//created//misc_data: miscData
+      static: {}

--- a/tests/config/junos/NAT_SESSION_CLOSED/recent/syslog.msg
+++ b/tests/config/junos/NAT_SESSION_CLOSED/recent/syslog.msg
@@ -1,0 +1,1 @@
+<14>Dec 13 13:12:00 srx-firewall RT_FLOW: RT_FLOW_SESSION_CLOSE: session closed idle Timeout: 172.16.0.1/23456->8.8.8.8/443 0x0 junos-https 172.16.0.2/12345->8.8.8.8/443 0x0 source rule LAN N/A N/A 6 allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN

--- a/tests/config/junos/NAT_SESSION_CLOSED/recent/yang.json
+++ b/tests/config/junos/NAT_SESSION_CLOSED/recent/yang.json
@@ -1,0 +1,44 @@
+{
+    "yang_message": {
+        "security": {
+            "flow": {
+                "closed": {
+                    "reason": "idle Timeout",
+                    "source_address": "172.16.0.1",
+                    "source_port": "23456",
+                    "destination_address": "8.8.8.8",
+                    "destination_port": "443",
+                    "service_name": "junos-https",
+                    "nat_source_address": "172.16.0.2",
+                    "nat_source_port": "12345",
+                    "nat_destination_address": "8.8.8.8",
+                    "nat_destination_port": "443",
+                    "src_nat_rule_name": "LAN",
+                    "protocol_id": "6",
+                    "misc_data": "allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN"
+                }
+            }
+        }
+    },
+    "message_details": {
+        "processId": null,
+        "severity": 6,
+        "facility": 1,
+        "hostPrefix": null,
+        "pri": "14",
+        "processName": "RT_FLOW",
+        "host": "srx-firewall",
+        "tag": "RT_FLOW_SESSION_CLOSE",
+        "time": "13:12:00",
+        "date": "Dec 13",
+        "message": "session closed idle Timeout: 172.16.0.1/23456->8.8.8.8/443 0x0 junos-https 172.16.0.2/12345->8.8.8.8/443 0x0 source rule LAN N/A N/A 6 allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN"
+    },
+    "timestamp": 1500587040,
+    "facility": 1,
+    "ip": "127.0.0.1",
+    "host": "srx-firewall",
+    "yang_model": "NO_MODEL",
+    "error": "NAT_SESSION_CLOSED",
+    "os": "junos",
+    "severity": 6
+}

--- a/tests/config/junos/NAT_SESSION_CREATED/recent/syslog.msg
+++ b/tests/config/junos/NAT_SESSION_CREATED/recent/syslog.msg
@@ -1,0 +1,1 @@
+<14>Dec 13 13:12:00 srx-firewall RT_FLOW: RT_FLOW_SESSION_CREATE: session created 172.16.0.1/23456->8.8.8.8/443 0x0 junos-https 172.16.0.2/12345->8.8.8.8/443 0x0 source rule LAN N/A N/A 6 allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN

--- a/tests/config/junos/NAT_SESSION_CREATED/recent/yang.json
+++ b/tests/config/junos/NAT_SESSION_CREATED/recent/yang.json
@@ -1,0 +1,43 @@
+{
+    "yang_message": {
+        "security": {
+            "flow": {
+                "created": {
+                    "source_address": "172.16.0.1",
+                    "source_port": "23456",
+                    "destination_address": "8.8.8.8",
+                    "destination_port": "443",
+                    "service_name": "junos-https",
+                    "nat_source_address": "172.16.0.2",
+                    "nat_source_port": "12345",
+                    "nat_destination_address": "8.8.8.8",
+                    "nat_destination_port": "443",
+                    "src_nat_rule_name": "LAN",
+                    "protocol_id": "6",
+                    "misc_data": "allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN"
+                }
+            }
+        }
+    },
+    "message_details": {
+        "processId": null,
+        "severity": 6,
+        "facility": 1,
+        "hostPrefix": null,
+        "pri": "14",
+        "processName": "RT_FLOW",
+        "host": "srx-firewall",
+        "tag": "RT_FLOW_SESSION_CREATE",
+        "time": "13:12:00",
+        "date": "Dec 13",
+        "message": "session created 172.16.0.1/23456->8.8.8.8/443 0x0 junos-https 172.16.0.2/12345->8.8.8.8/443 0x0 source rule LAN N/A N/A 6 allow-any PRIVATE PUBLIC 123456 N/A(N/A) hu-1/0/0.0 UNKNOWN UNKNOWN UNKNOWN"
+    },
+    "timestamp": 1500587040,
+    "facility": 1,
+    "ip": "127.0.0.1",
+    "host": "srx-firewall",
+    "yang_model": "NO_MODEL",
+    "error": "NAT_SESSION_CREATED",
+    "os": "junos",
+    "severity": 6
+}


### PR DESCRIPTION
For some reason, "recent" JunOS versions seem to add this in the log.