### PR TITLE
Add junos NH_REGION_GRAB_FAILED

### DIFF
--- a/napalm_logs/config/junos/NH_REGION_GRAB_FAILED.yml
+++ b/napalm_logs/config/junos/NH_REGION_GRAB_FAILED.yml
@@ -1,0 +1,15 @@
+messages:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: NH_REGION_GRAB_FAILED
+    tag: JPRDS_NH
+    values:
+      id: (\d+)
+      nh: (\d+)
+    line: 'jprds_nh_alloc(),{id}: JNH[0] failed to grab new region for NH#{nh}'
+    model: NO_MODEL
+    mapping:
+      variables:
+        nh//region//failed//id: id
+        nh//region//failed//nh: nh
+      static: {}

--- a/napalm_logs/config/junos/init.yml
+++ b/napalm_logs/config/junos/init.yml
@@ -36,3 +36,16 @@ prefixes:
       # Some logs have data which can be inside brackets or parenthesis
       additionalData: (?:(?:\[|\()(.+)(?:\]|\)))?
     line: '{date} {time} {hostPrefix}{host} fpc{fpcId} {tag}{additionalData}:'
+  # The following matches dcpfe specific logs
+  - time_format: "%b %d %H:%M:%S"
+    values:
+      date: (\w+\s+\d+)
+      time: (\d\d:\d\d:\d\d)
+      hostPrefix: (re\d.)?
+      host: ([^ ]+)
+      fpcId: (\d+)
+      fpcId2: (\d+)
+      tag: (\w+)
+      # Some logs have data which can be inside brackets or parenthesis
+      additionalData: (?:(?:\[|\()(.+)(?:\]|\)))?
+    line: '{date} {time} {hostPrefix}{host} fpc{fpcId} fpc{fpcId2} dcpfe: {tag}{additionalData}:'

--- a/tests/config/junos/NH_REGION_GRAB_FAILED/default/syslog.msg
+++ b/tests/config/junos/NH_REGION_GRAB_FAILED/default/syslog.msg
@@ -1,0 +1,1 @@
+<7>Dec 10 00:00:01  re0.edge01.bjm01 fpc3 fpc3 dcpfe: JPRDS_NH:jprds_nh_alloc(),631: JNH[0] failed to grab new region for NH#007

--- a/tests/config/junos/NH_REGION_GRAB_FAILED/default/yang.json
+++ b/tests/config/junos/NH_REGION_GRAB_FAILED/default/yang.json
@@ -1,0 +1,34 @@
+{
+  "yang_message": {
+    "nh": {
+      "region": {
+        "failed": {
+          "nh": "007",
+          "id": "631"
+        }
+      }
+    }
+  },
+  "message_details": {
+    "additionalData": null,
+    "severity": 7,
+    "facility": 0,
+    "hostPrefix": "re0.",
+    "pri": "7",
+    "host": "edge01.bjm01",
+    "tag": "JPRDS_NH",
+    "fpcId": "3",
+    "fpcId2": "3",
+    "time": "00:00:01",
+    "date": "Dec 10",
+    "message": "jprds_nh_alloc(),631: JNH[0] failed to grab new region for NH#007"
+  },
+  "facility": 0,
+  "ip": "127.0.0.1",
+  "error": "NH_REGION_GRAB_FAILED",
+  "host": "edge01.bjm01",
+  "yang_model": "NO_MODEL",
+  "timestamp": 1575936001,
+  "os": "junos",
+  "severity": 7
+}


### PR DESCRIPTION
Several fpc specific log messages have a different format, they have the
fpc listed twice, then have `dcpfe:` before the tag. Here is an example:

```
<7>Dec 10 00:00:01  re0.edge01.bjm01 fpc3 fpc3 dcpfe:
JPRDS_NH:jprds_nh_alloc(),631: JNH[0] failed to grab new region for
NH#007
```

I have added a new entry to the junos init to match this. As well as
adding a new entry for the `JPRDS_NH` tag.