### PR TITLE
[tests] Remove warning

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,5 @@ jinja2
 coveralls
 pytest-cov
 pytest-json
-pytest-catchlog
 pytest-pythonpath
 flake8-import-order


### PR DESCRIPTION
Fixing : pytest-catchlog plugin has been merged into the core, please remove it from you requirements.