### PR TITLE
Add log processing delay metric

### DIFF
--- a/napalm_logs/listener_proc.py
+++ b/napalm_logs/listener_proc.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 # Import pythond stdlib
 import os
+import time
 import signal
 import logging
 import threading
@@ -102,6 +103,7 @@ class NapalmLogsListenerProc(NapalmLogsProc):
         while self.__up:
             try:
                 log_message, log_source = self.listener.receive()
+                receive_timestamp = time.time()
             except ListenerException as lerr:
                 if self.__up is False:
                     log.info('Exiting on process shutdown')
@@ -114,7 +116,7 @@ class NapalmLogsListenerProc(NapalmLogsProc):
                 log.info('Empty message received from %s. Not queueing to the server.', log_source)
                 continue
             c_logs_ingested.labels(listener_type=self._listener_type, address=self.address, port=self.port).inc()
-            self.pub.send(umsgpack.packb((log_message, log_source)))
+            self.pub.send(umsgpack.packb((log_message, log_source, receive_timestamp)))
             c_messages_published.labels(listener_type=self._listener_type, address=self.address, port=self.port).inc()
 
     def stop(self):

--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -265,7 +265,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
             # Take messages from the main queue
             try:
                 bin_obj = self.sub.recv()
-                msg, address = umsgpack.unpackb(bin_obj, use_list=False)
+                msg, address, recv_ts = umsgpack.unpackb(bin_obj, use_list=False)
             except zmq.ZMQError as error:
                 if self.__up is False:
                     log.info('Exiting on process shutdown')
@@ -283,6 +283,7 @@ class NapalmLogsServerProc(NapalmLogsProc):
             os_list = self._identify_os(msg)
 
             for dev_os, msg_dict in os_list:
+                msg_dict['_napalm_logs_received_timestamp'] = recv_ts
                 if dev_os and dev_os in self.started_os_proc:
                     # Identified the OS and the corresponding process is started.
                     # Then send the message in the right queue


### PR DESCRIPTION
Expose a new metric ``napalm_logs_processing_delay`` that provides
a (rough?) view on how long it takes a message to be processed through
napalm-logs - from the moment the message is received, till published.
This timing excludes the time spent effectively publishing (as it may
depend of various external factors), but it includes the time spent in
the internal queues.

Example:

```
# HELP napalm_logs_processing_delay Multiprocess metric
# TYPE napalm_logs_processing_delay gauge
napalm_logs_processing_delay{address="0.0.0.0",pid="17389",port="49017",publisher_type="zmq"} 0.001567363739013671
```

I'm wondering whether it makes sense to have the labels from the publisher (i.e., have separate delay report for each distinct publisher). Or even have labels from the message type (e.g., `napalm_logs_processing_delay{error='BGP_PREFIX_LIMIT_EXCEEDED'} 0.001567363739013671`? Or not at all maybe... :thinking: 