### PR TITLE
BGP_MD5_INCORRECT notification on missing MD5 digest message

### DIFF
--- a/napalm_logs/config/junos/BGP_MD5_INCORRECT.yml
+++ b/napalm_logs/config/junos/BGP_MD5_INCORRECT.yml
@@ -6,7 +6,7 @@ messages:
   - error: BGP_MD5_INCORRECT
     tag: tcp_auth_ok
     values:
-      peer: (\d+\.\d+\.\d+\.\d+)
+      peer: ([\w\d:\.]+)
       port: (\d+)
     line: 'Packet from {peer}:{port} wrong MD5 digest'
     model: openconfig-bgp
@@ -14,3 +14,14 @@ messages:
       variables: {}
       static:
         bgp//neighbors//neighbor//{peer}//state//session_state: CONNECT
+  - error: BGP_MD5_INCORRECT
+    tag: tcp_auth_ok
+    values:
+      peer: ([\w\d:\.]+)
+      port: (\d+)
+    line: 'Packet from {peer}:{port} missing MD5 digest'
+    model: openconfig-bgp
+    mapping:
+      variables: {}
+      static:
+        bgp//neighbors//neighbor//{peer}//state//session_state: ACTIVE

--- a/tests/config/junos/BGP_MD5_INCORRECT/ipv6/syslog.msg
+++ b/tests/config/junos/BGP_MD5_INCORRECT/ipv6/syslog.msg
@@ -1,0 +1,1 @@
+<4>Jul 20 21:23:00 vmx01 /kernel: tcp_auth_ok: Packet from 2001:db8:1::a502:764:1:61664 wrong MD5 digest

--- a/tests/config/junos/BGP_MD5_INCORRECT/ipv6/yang.json
+++ b/tests/config/junos/BGP_MD5_INCORRECT/ipv6/yang.json
@@ -1,0 +1,36 @@
+{
+  "yang_message": {
+    "bgp": {
+      "neighbors": {
+        "neighbor": {
+          "2001:db8:1::a502:764:1": {
+            "state": {
+              "session_state": "CONNECT"
+            }
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "processId": null,
+    "severity": 4,
+    "facility": 0,
+    "hostPrefix": null,
+    "pri": "4",
+    "processName": "kernel",
+    "host": "vmx01",
+    "tag": "tcp_auth_ok",
+    "time": "21:23:00",
+    "date": "Jul 20",
+    "message": "Packet from 2001:db8:1::a502:764:1:61664 wrong MD5 digest"
+  },
+  "timestamp": 1500585780,
+  "facility": 0,
+  "ip": "127.0.0.1",
+  "host": "vmx01",
+  "yang_model": "openconfig-bgp",
+  "error": "BGP_MD5_INCORRECT",
+  "os": "junos",
+  "severity": 4
+}

--- a/tests/config/junos/BGP_MD5_INCORRECT/missing/syslog.msg
+++ b/tests/config/junos/BGP_MD5_INCORRECT/missing/syslog.msg
@@ -1,0 +1,1 @@
+<4>Jul 20 21:23:00 vmx01 kernel: tcp_auth_ok: Packet from 192.168.140.254:61664 missing MD5 digest

--- a/tests/config/junos/BGP_MD5_INCORRECT/missing/yang.json
+++ b/tests/config/junos/BGP_MD5_INCORRECT/missing/yang.json
@@ -1,0 +1,36 @@
+{
+  "yang_message": {
+    "bgp": {
+      "neighbors": {
+        "neighbor": {
+          "192.168.140.254": {
+            "state": {
+              "session_state": "ACTIVE"
+            }
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "processId": null,
+    "severity": 4,
+    "facility": 0,
+    "hostPrefix": null,
+    "pri": "4",
+    "processName": "kernel",
+    "host": "vmx01",
+    "tag": "tcp_auth_ok",
+    "time": "21:23:00",
+    "date": "Jul 20",
+    "message": "Packet from 192.168.140.254:61664 missing MD5 digest"
+  },
+  "timestamp": 1500585780,
+  "facility": 0,
+  "ip": "127.0.0.1",
+  "host": "vmx01",
+  "yang_model": "openconfig-bgp",
+  "error": "BGP_MD5_INCORRECT",
+  "os": "junos",
+  "severity": 4
+}


### PR DESCRIPTION
Group ``missing MD5 digest`` message types under the BGP_MD5_INCORRECT
notification, as I'm thinking it's virtually the same (i.e., missing
is approximatively the same as incorrect).

I've also noticed that the current configuration wouldn't match v6 peers,
so I'm correcting this on this occasion.