### PR TITLE
Update Dockerfile to install python3-dev instead of python-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./ /var/cache/napalm-logs/
 RUN apk add --no-cache \
     libffi \
     libffi-dev \
-    python-dev \
+    python3-dev \
     build-base \
     && pip --no-cache-dir install cffi /var/cache/napalm-logs/ \
     && rm -rf /var/cache/napalm-logs/


### PR DESCRIPTION
Currently the build is failing because of this:

```
ERROR: unsatisfiable constraints:
  python-dev (missing):
    required by: world[python-dev]
The command '/bin/sh -c apk add --no-cache     libffi     libffi-dev     python-dev     build-base     && pip --no-cache-dir install cffi /var/cache/napalm-logs/     && rm -rf /var/cache/napalm-logs/' returned a non-zero code: 1
```