### PR TITLE
PROCESS_CEILING_WATERMARK_REACHED notification on breaching process watermarks

### DIFF
--- a/napalm_logs/config/junos/PROCESS_CEILING_WATERMARK_REACHED.yml
+++ b/napalm_logs/config/junos/PROCESS_CEILING_WATERMARK_REACHED.yml
@@ -1,0 +1,13 @@
+messages:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: PROCESS_CEILING_WATERMARK_REACHED
+    tag: jlaunchd
+    values:
+      severity: (\w+)
+    line: 'System reaching processes ceiling {severity} watermark: Contact to system administrator to clean up unnecessary processes or increase maxproc ceiling.'
+    model: NO_MODEL
+    mapping:
+      variables:
+        jlaunchd//watermark//severity: severity
+      static: {}


### PR DESCRIPTION
Juniper sends log messages when the different process ceiling watermarks are breached. These errors indicate the system is close to resource exhaustion.
This fixes #344

Example of the logs:
```
jlaunchd: System reaching processes ceiling critical watermark: Contact to system administrator to clean up unnecessary processes or increase maxproc ceiling. Further non-suid process fork request will be denied.
```
```
jlaunchd: System reaching processes ceiling low watermark: Contact to system administrator to clean up unnecessary processes or increase maxproc ceiling.
```