### PR TITLE
Update PROCESS_CEILING_WATERMARK_REACHED error processing

### DIFF
--- a/napalm_logs/config/junos/PROCESS_CEILING_WATERMARK_REACHED.yml
+++ b/napalm_logs/config/junos/PROCESS_CEILING_WATERMARK_REACHED.yml
@@ -9,5 +9,5 @@ messages:
     model: NO_MODEL
     mapping:
       variables:
-        jlaunchd//watermark//severity: severity
+        process//ceiling//watermark: severity
       static: {}

--- a/napalm_logs/config/junos/init.yml
+++ b/napalm_logs/config/junos/init.yml
@@ -4,6 +4,15 @@
 # Matching white space in `values`
 #
 prefixes:
+  # jlaunchd doesn't have proper tags. Override the match to use jlaunchd as the tag instead.
+  - time_format: "%b %d %H:%M:%S"
+    values:
+      date: (\w+ +\d+)
+      time: (\d\d:\d\d:\d\d)
+      hostPrefix: (re\d.)?
+      host: ([^ ]+)
+      tag: (jlaunchd)
+    line: '{date} {time} {hostPrefix}{host} {tag}: '
   - time_format: '%b %d %H:%M:%S'
     values:
       date: (\w+\s+\d+)
@@ -51,6 +60,15 @@ prefixes:
     line: '{date} {time} {hostPrefix}{host} fpc{fpcId} fpc{fpcId2} dcpfe: {tag}{additionalData}:'
 
   # Same structures as above, but to match the ISO8601 date-time format.
+    # jlaunchd doesn't have proper tags. Override the match to use jlaunchd as the tag instead.
+  - time_format: "%b %d %H:%M:%S"
+    values:
+      date: (\d{4}-\d{2}-\d{2})
+      time: (\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})
+      hostPrefix: (re\d.)?
+      host: ([^ ]+)
+      tag: (jlaunchd)
+    line: '{date}T{time} {hostPrefix}{host} {tag}: '
   - time_format: '%b %d %H:%M:%S'
     values:
       date: (\d{4}-\d{2}-\d{2})

--- a/tests/config/junos/PROCESS_CEILING_WATERMARK_REACHED/default/syslog.msg
+++ b/tests/config/junos/PROCESS_CEILING_WATERMARK_REACHED/default/syslog.msg
@@ -1,0 +1,1 @@
+<32>Oct 24 20:21:27  vmx01 jlaunchd: System reaching processes ceiling high watermark: Contact to system administrator to clean up unnecessary processes or increase maxproc ceiling. Further process fork request may be denied.

--- a/tests/config/junos/PROCESS_CEILING_WATERMARK_REACHED/default/yang.json
+++ b/tests/config/junos/PROCESS_CEILING_WATERMARK_REACHED/default/yang.json
@@ -1,0 +1,28 @@
+{
+    "host": "vmx01",
+    "yang_message": {
+        "process": {
+            "ceiling": {
+                "watermark": "high"
+            }
+        }
+    },
+    "message_details": {
+        "facility": 4,
+        "hostPrefix": null,
+        "pri": "32",
+        "host": "vmx01",
+        "tag": "jlaunchd",
+        "time": "20:21:27",
+        "date": "Oct 24",
+        "message": "System reaching processes ceiling high watermark: Contact to system administrator to clean up unnecessary processes or increase maxproc ceiling. Further process fork request may be denied.",
+        "severity": 0
+    },
+    "timestamp": 1603570887,
+    "error": "PROCESS_CEILING_WATERMARK_REACHED",
+    "ip": "127.0.0.1",
+    "facility": 4,
+    "os": "junos",
+    "yang_model": "NO_MODEL",
+    "severity": 0
+}


### PR DESCRIPTION
`jlaunchd` doesn't present its messages with a tag. As such, with the default parsing, the `jlaunchd` message interpreted `System reaching processes ceiling high watermark` as the tag. Using this would mean duplication of the syslog parsing, as we'd have to duplicate for every instance of severity.
Updated the `init.yml` file to add an explicit parser for `jlaunchd` messages where `jlaunchd` becomes the tag.
Added a test as well