### PR TITLE
TCP Listener: do not raise on socket timeout, logging is sufficient

### DIFF
--- a/napalm_logs/listener/tcp.py
+++ b/napalm_logs/listener/tcp.py
@@ -95,8 +95,7 @@ class TCPListener(ListenerBase):
         except socket.timeout:
             if not self.__up:
                 return
-            log.debug('Connection %s:%d timed out', addr[1], addr[0])
-            raise ListenerException('Connection %s:%d timed out' % addr)
+            log.error('Connection %s:%d timed out', addr[1], addr[0])
         finally:
             log.debug('Closing connection with %s', addr)
             conn.close()


### PR DESCRIPTION
When serving multiple clients, it's entirely normal for them to timeout,
and eventually try to connect later due to inactivity. There's no reason
to raise hard error, and kill the entire application just because a peer
is no longer active.