### PR TITLE
Add MAJOR_ALARM_SET and MAJOR_ALARM_CLEARED pair

### DIFF
--- a/napalm_logs/config/junos/MAJOR_ALARM_CLEARED.yml
+++ b/napalm_logs/config/junos/MAJOR_ALARM_CLEARED.yml
@@ -1,0 +1,11 @@
+messages:
+  - error: MAJOR_ALARM_CLEARED
+    tag: craftd
+    values:
+      reason: (.*)
+    line: 'Major alarm cleared, {reason}'
+    model: ietf-alarm
+    mapping:
+      variables:
+        alarms//alarm//additional-text: reason
+      static: {}

--- a/napalm_logs/config/junos/MAJOR_ALARM_SET.yml
+++ b/napalm_logs/config/junos/MAJOR_ALARM_SET.yml
@@ -1,3 +1,9 @@
+# This message is dedicated to the major alarms, as a specific subset of the
+# SYSTEM_ALARM. While providing fewer details than the SYSTEM_ALARM notifications
+# it is a more reliable source of the alarm status, as SYSTEM_ALARM through the
+# color scheme YELLOW / RED doesn't accurately provide the severity of the alarm
+# (i.e., some major alarms are marked as YELLOW, while some minor alarms can be
+# marked as YELLOW as well - and vice-versa).
 messages:
   - error: MAJOR_ALARM_SET
     tag: craftd

--- a/napalm_logs/config/junos/MAJOR_ALARM_SET.yml
+++ b/napalm_logs/config/junos/MAJOR_ALARM_SET.yml
@@ -1,0 +1,11 @@
+messages:
+  - error: MAJOR_ALARM_SET
+    tag: craftd
+    values:
+      reason: (.*)
+    line: 'Major alarm set, {reason}'
+    model: ietf-alarm
+    mapping:
+      variables:
+        alarms//alarm//additional-text: reason
+      static: {}

--- a/napalm_logs/config/junos/MINOR_ALARM_CLEARED.yml
+++ b/napalm_logs/config/junos/MINOR_ALARM_CLEARED.yml
@@ -1,0 +1,11 @@
+messages:
+  - error: MINOR_ALARM_CLEARED
+    tag: craftd
+    values:
+      reason: (.*)
+    line: 'Minor alarm cleared, {reason}'
+    model: ietf-alarm
+    mapping:
+      variables:
+        alarms//alarm//additional-text: reason
+      static: {}

--- a/napalm_logs/config/junos/MINOR_ALARM_SET.yml
+++ b/napalm_logs/config/junos/MINOR_ALARM_SET.yml
@@ -1,0 +1,17 @@
+# This message is dedicated to the major alarms, as a specific subset of the
+# SYSTEM_ALARM. While providing fewer details than the SYSTEM_ALARM notifications
+# it is a more reliable source of the alarm status, as SYSTEM_ALARM through the
+# color scheme YELLOW / RED doesn't accurately provide the severity of the alarm
+# (i.e., some major alarms are marked as YELLOW, while some minor alarms can be
+# marked as YELLOW as well - and vice-versa).
+messages:
+  - error: MINOR_ALARM_SET
+    tag: craftd
+    values:
+      reason: (.*)
+    line: 'Minor alarm set, {reason}'
+    model: ietf-alarm
+    mapping:
+      variables:
+        alarms//alarm//additional-text: reason
+      static: {}

--- a/tests/config/junos/MAJOR_ALARM_CLEARED/default/syslog.msg
+++ b/tests/config/junos/MAJOR_ALARM_CLEARED/default/syslog.msg
@@ -1,0 +1,1 @@
+<28>Jul  8 23:04:13  vmx01 craftd[4817]:  Major alarm cleared, Host 0 me0 : Ethernet Link Down

--- a/tests/config/junos/MAJOR_ALARM_CLEARED/default/yang.json
+++ b/tests/config/junos/MAJOR_ALARM_CLEARED/default/yang.json
@@ -1,0 +1,29 @@
+{
+  "error": "MAJOR_ALARM_CLEARED",
+  "host": "vmx01",
+  "ip": "127.0.0.1",
+  "timestamp": 1594249453,
+  "yang_message": {
+    "alarms": {
+      "alarm": {
+        "additional-text": "Host 0 me0 : Ethernet Link Down"
+      }
+    }
+  },
+  "message_details": {
+    "date": "Jul  8",
+    "time": "23:04:13",
+    "hostPrefix": null,
+    "host": "vmx01",
+    "tag": "craftd",
+    "processId": "4817",
+    "pri": "28",
+    "message": "Major alarm cleared, Host 0 me0 : Ethernet Link Down",
+    "facility": 3,
+    "severity": 4
+  },
+  "yang_model": "ietf-alarm",
+  "os": "junos",
+  "facility": 3,
+  "severity": 4
+}

--- a/tests/config/junos/MAJOR_ALARM_SET/default/syslog.msg
+++ b/tests/config/junos/MAJOR_ALARM_SET/default/syslog.msg
@@ -1,0 +1,1 @@
+<28>Jul  8 23:04:13  vmx01 craftd[4817]:  Major alarm set, Host 0 me0 : Ethernet Link Down

--- a/tests/config/junos/MAJOR_ALARM_SET/default/yang.json
+++ b/tests/config/junos/MAJOR_ALARM_SET/default/yang.json
@@ -1,0 +1,29 @@
+{
+  "error": "MAJOR_ALARM_SET",
+  "host": "vmx01",
+  "ip": "127.0.0.1",
+  "timestamp": 1594249453,
+  "yang_message": {
+    "alarms": {
+      "alarm": {
+        "additional-text": "Host 0 me0 : Ethernet Link Down"
+      }
+    }
+  },
+  "message_details": {
+    "date": "Jul  8",
+    "time": "23:04:13",
+    "hostPrefix": null,
+    "host": "vmx01",
+    "tag": "craftd",
+    "processId": "4817",
+    "pri": "28",
+    "message": "Major alarm set, Host 0 me0 : Ethernet Link Down",
+    "facility": 3,
+    "severity": 4
+  },
+  "yang_model": "ietf-alarm",
+  "os": "junos",
+  "facility": 3,
+  "severity": 4
+}

--- a/tests/config/junos/MINOR_ALARM_CLEARED/default/syslog.msg
+++ b/tests/config/junos/MINOR_ALARM_CLEARED/default/syslog.msg
@@ -1,0 +1,1 @@
+<28>Jul  8 23:04:13  vmx01 craftd[4817]:  Minor alarm cleared, RE 0 /var partition usage is high

--- a/tests/config/junos/MINOR_ALARM_CLEARED/default/yang.json
+++ b/tests/config/junos/MINOR_ALARM_CLEARED/default/yang.json
@@ -1,0 +1,29 @@
+{
+  "ip": "127.0.0.1", 
+  "yang_message": {
+    "alarms": {
+      "alarm": {
+        "additional-text": "RE 0 /var partition usage is high"
+      }
+    }
+  }, 
+  "host": "vmx01", 
+  "error": "MINOR_ALARM_CLEARED", 
+  "facility": 3, 
+  "yang_model": "ietf-alarm", 
+  "os": "junos", 
+  "severity": 4, 
+  "message_details": {
+    "date": "Jul  8", 
+    "processId": "4817", 
+    "tag": "craftd", 
+    "host": "vmx01", 
+    "hostPrefix": null, 
+    "message": "Minor alarm cleared, RE 0 /var partition usage is high", 
+    "facility": 3, 
+    "severity": 4, 
+    "pri": "28", 
+    "time": "23:04:13"
+  }, 
+  "timestamp": 1594249453
+}

--- a/tests/config/junos/MINOR_ALARM_SET/default/syslog.msg
+++ b/tests/config/junos/MINOR_ALARM_SET/default/syslog.msg
@@ -1,0 +1,1 @@
+<28>Jul  8 23:04:13  vmx01 craftd[4817]:  Minor alarm set, RE 0 /var partition usage is high

--- a/tests/config/junos/MINOR_ALARM_SET/default/yang.json
+++ b/tests/config/junos/MINOR_ALARM_SET/default/yang.json
@@ -1,0 +1,29 @@
+{
+  "host": "vmx01", 
+  "yang_model": "ietf-alarm", 
+  "ip": "127.0.0.1", 
+  "message_details": {
+    "host": "vmx01", 
+    "pri": "28", 
+    "time": "23:04:13", 
+    "message": "Minor alarm set, RE 0 /var partition usage is high", 
+    "severity": 4, 
+    "tag": "craftd", 
+    "hostPrefix": null, 
+    "processId": "4817", 
+    "facility": 3, 
+    "date": "Jul  8"
+  }, 
+  "yang_message": {
+    "alarms": {
+      "alarm": {
+        "additional-text": "RE 0 /var partition usage is high"
+      }
+    }
+  }, 
+  "severity": 4, 
+  "timestamp": 1594249453, 
+  "error": "MINOR_ALARM_SET", 
+  "os": "junos", 
+  "facility": 3
+}


### PR DESCRIPTION
This message is dedicated to the major alarms, as a specific subset of the
SYSTEM_ALARM. While providing fewer details than the SYSTEM_ALARM notifications
it is a more reliable source of the alarm status, as SYSTEM_ALARM through the
color scheme YELLOW / RED doesn't accurately provide the severity of the alarm
(i.e., some major alarms are marked as YELLOW, while some minor alarms can be
marked as YELLOW as well - and vice-versa).