### PR TITLE
Add Junos counter-part INTERFACE_UP notification

### DIFF
--- a/napalm_logs/config/junos/INTERFACE_UP.yml
+++ b/napalm_logs/config/junos/INTERFACE_UP.yml
@@ -1,0 +1,19 @@
+messages:
+  # 'error' should be unique and vendor agnostic. Currently we are using the JUNOS syslog message name as the canonical name.
+  # This may change if we are able to find a more well defined naming system.
+  - error: INTERFACE_UP
+    tag: SNMP_TRAP_LINK_UP
+    values:
+      snmpID: (\d+)
+      adminStatusString|upper: (\w+)
+      adminStatusValue: (\d)
+      operStatusString|upper: (\w+)
+      operStatusValue: (\d)
+      interface: ([\w\-\/\:]+)
+    line: 'ifIndex {snmpID}, ifAdminStatus {adminStatusString}({adminStatusValue}), ifOperStatus {operStatusString}({operStatusValue}), ifName {interface}'
+    model: openconfig-interfaces
+    mapping:
+      variables:
+        interfaces//interface//{interface}//state//admin_status: adminStatusString
+        interfaces//interface//{interface}//state//oper_status: operStatusString
+      static: {}

--- a/tests/config/junos/INTERFACE_UP/default/syslog.msg
+++ b/tests/config/junos/INTERFACE_UP/default/syslog.msg
@@ -1,0 +1,1 @@
+<28>Jul 20 21:45:59 vmx01 mib2d[2424]: SNMP_TRAP_LINK_UP: ifIndex 502, ifAdminStatus up(1), ifOperStatus up(1), ifName xe-0/0/0

--- a/tests/config/junos/INTERFACE_UP/default/yang.json
+++ b/tests/config/junos/INTERFACE_UP/default/yang.json
@@ -1,0 +1,35 @@
+{
+  "yang_message": {
+    "interfaces": {
+      "interface": {
+        "xe-0/0/0": {
+          "state": {
+            "oper_status": "UP",
+            "admin_status": "UP"
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "processId": "2424",
+    "severity": 4,
+    "facility": 3,
+    "hostPrefix": null,
+    "pri": "28",
+    "processName": "mib2d",
+    "host": "vmx01",
+    "tag": "SNMP_TRAP_LINK_UP",
+    "time": "21:45:59",
+    "date": "Jul 20",
+    "message": "ifIndex 502, ifAdminStatus up(1), ifOperStatus up(1), ifName xe-0/0/0"
+  },
+  "timestamp": 1500587159,
+  "facility": 3,
+  "ip": "127.0.0.1",
+  "host": "vmx01",
+  "yang_model": "openconfig-interfaces",
+  "error": "INTERFACE_UP",
+  "os": "junos",
+  "severity": 4
+}


### PR DESCRIPTION
Strangely, this was missing, although INTERFACE_DOWN is defined, likely
because this wasn't being thrown on older Junos versions, but on modern
software there is.