### PR TITLE
[385] Fix for stuck consumers due to unsafe host key access

### DIFF
--- a/napalm_logs/server.py
+++ b/napalm_logs/server.py
@@ -301,7 +301,9 @@ class NapalmLogsServerProc(NapalmLogsProc):
                     if self._buffer:
                         message = "{dev_os}/{host}/{msg}".format(
                             dev_os=dev_os.decode(),
-                            host=msg_dict["host"],
+                            # Host is not always present (e.g IOS-XR by default doesn't include the hostname in the message)
+                            # This ensures the key is safely accessed and returns 'unknown' if not present.
+                            host=msg_dict.get("host", "unknown"),
                             msg=msg_dict["message"],
                         )
                         message_key = base64.b64encode(bytes(message, "utf-8")).decode()
@@ -327,7 +329,9 @@ class NapalmLogsServerProc(NapalmLogsProc):
                     if self.opts.get("metrics_server_include_attributes", True):
                         napalm_logs_server_messages_attrs.labels(
                             device_os=dev_os.decode(),
-                            host=msg_dict["host"],
+                            # Host is not always present (e.g IOS-XR by default doesn't include the hostname in the message).
+                            # This ensures the key is safely accessed and returns 'unknown' if not present.
+                            host=msg_dict.get("host", "unknown"),
                             tag=msg_dict["tag"],
                         ).inc()
 


### PR DESCRIPTION
This PR addresses: https://github.com/napalm-automation/napalm-logs/issues/385

Vendors like IOS-XR by default send messages with no hostname. The napalm-logs ios-xr parser was updated to support this default behaviour. However, server.py has unsafe access logic for the host key in msg_dict which can cause the consumer/listeners to become stuck as they are expecting messages to have a host key for lookup.

This PR turns makes the host key access safe and returns a default value of "unknown" if the host key doesn't exist.

Signed-off-by: Adrian Arumugam <adrian@a6m.au>
