### PR TITLE
fix: Remove EOS extra char in messages

### DIFF
--- a/napalm_logs/config/eos/init.yml
+++ b/napalm_logs/config/eos/init.yml
@@ -11,7 +11,7 @@ prefixes:
       host: ([^ ]+)
       processName: ([\w-]+)
       tag: ([\w-]+)
-    line: '{date} {time} {host} {processName}: %{tag}'
+    line: '{date} {time} {host} {processName}: %{tag}: '
   # ISO8601 date-time format
   - values:
       date: (\d{4}-\d{2}-\d{2})
@@ -19,4 +19,4 @@ prefixes:
       host: ([^ ]+)
       processName: ([\w-]+)
       tag: ([\w-]+)
-    line: '{date}T{time} {host} {processName}: %{tag}'
+    line: '{date}T{time} {host} {processName}: %{tag}: '

--- a/tests/config/eos/AGENT_INITIALIZED/default/yang.json
+++ b/tests/config/eos/AGENT_INITIALIZED/default/yang.json
@@ -22,7 +22,7 @@
     "tag": "AGENT-6-INITIALIZED",
     "time": "14:39:03",
     "date": "Oct 18",
-    "message": ": Agent 'Rib' initialized; pid=7104"
+    "message": "Agent 'Rib' initialized; pid=7104"
   },
   "facility": 20,
   "ip": "127.0.0.1",

--- a/tests/config/eos/BFD_STATE_CHANGE/down_to_up/yang.json
+++ b/tests/config/eos/BFD_STATE_CHANGE/down_to_up/yang.json
@@ -22,7 +22,7 @@
     "host": "HOSTNAME",
     "tag": "BFD-5-STATE_CHANGE",
     "time": "22:22:35",
-    "message": ": peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Down to Up diag None",
+    "message": "peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Down to Up diag None",
     "facility": 20,
     "processName": "Bfd"
   },

--- a/tests/config/eos/BFD_STATE_CHANGE/init_to_up/yang.json
+++ b/tests/config/eos/BFD_STATE_CHANGE/init_to_up/yang.json
@@ -22,7 +22,7 @@
     "host": "HOSTNAME",
     "tag": "BFD-5-STATE_CHANGE",
     "time": "22:22:35",
-    "message": ": peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Init to Up diag None",
+    "message": "peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Init to Up diag None",
     "facility": 20,
     "processName": "Bfd"
   },

--- a/tests/config/eos/BFD_STATE_CHANGE/up_to_down/yang.json
+++ b/tests/config/eos/BFD_STATE_CHANGE/up_to_down/yang.json
@@ -22,7 +22,7 @@
     "host": "HOSTNAME",
     "tag": "BFD-5-STATE_CHANGE",
     "time": "22:22:26",
-    "message": ": peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Up to Down diag None",
+    "message": "peer (vrf:default, ip:18.11.5.1, intf:Ethernet50/1, srcIp:0.0.0.0, type:normal) changed state from Up to Down diag None",
     "facility": 20,
     "processName": "Bfd"
   },

--- a/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/ISO8601_datetime/yang.json
+++ b/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/ISO8601_datetime/yang.json
@@ -9,7 +9,7 @@
     "date": "2020-03-31", 
     "facility": 1, 
     "host": "some-switch", 
-    "message": ": peer 192.0.2.2 (VRF default AS 12345) old state Established event AdminReset new state Idle"
+    "message": "peer 192.0.2.2 (VRF default AS 12345) old state Established event AdminReset new state Idle"
   }, 
   "os": "eos", 
   "timestamp": 1585644119, 

--- a/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/established_to_idle/yang.json
+++ b/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/established_to_idle/yang.json
@@ -22,7 +22,7 @@
     "host": "HOSTNAME",
     "tag": "BGP-5-ADJCHANGE",
     "time": "12:08:59",
-    "message": ": peer 192.0.2.2 (VRF default AS 12345) old state Established event AdminReset new state Idle",
+    "message": "peer 192.0.2.2 (VRF default AS 12345) old state Established event AdminReset new state Idle",
     "facility": 1,
     "processName": "Bgp"
   },

--- a/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/openconfirm_to_established/yang.json
+++ b/tests/config/eos/BGP_NEIGHBOR_STATE_CHANGED/openconfirm_to_established/yang.json
@@ -22,7 +22,7 @@
     "host": "HOSTNAME",
     "tag": "BGP-5-ADJCHANGE",
     "time": "12:09:00",
-    "message": ": peer 192.0.2.2 (VRF default AS 12345) old state OpenConfirm event Established new state Established",
+    "message": "peer 192.0.2.2 (VRF default AS 12345) old state OpenConfirm event Established new state Established",
     "facility": 1,
     "processName": "Bgp"
   },

--- a/tests/config/eos/BGP_PREFIX_LIMIT_EXCEEDED/default/yang.json
+++ b/tests/config/eos/BGP_PREFIX_LIMIT_EXCEEDED/default/yang.json
@@ -22,7 +22,7 @@
     "tag": "BGP-3-NOTIFICATION",
     "time": "11:04:17",
     "date": "Apr 16",
-    "message": ": received from neighbor 194.53.172.97 (AS 2611) 6/1 (Cease/maximum number of prefixes reached) 0 bytes"
+    "message": "received from neighbor 194.53.172.97 (AS 2611) 6/1 (Cease/maximum number of prefixes reached) 0 bytes"
   },
   "timestamp": 1492340657,
   "facility": 18,

--- a/tests/config/eos/INTERFACE_DOWN/default/yang.json
+++ b/tests/config/eos/INTERFACE_DOWN/default/yang.json
@@ -19,7 +19,7 @@
     "tag": "LINEPROTO-5-UPDOWN",
     "time": "09:42:36",
     "date": "Feb  6",
-    "message": ": Line protocol on Interface Ethernet28, changed state to down"
+    "message": "Line protocol on Interface Ethernet28, changed state to down"
   },
   "facility": 20,
   "ip": "127.0.0.1",

--- a/tests/config/eos/INTERFACE_UP/consistency_ftw/yang.json
+++ b/tests/config/eos/INTERFACE_UP/consistency_ftw/yang.json
@@ -19,7 +19,7 @@
     "tag": "LINEPROTO-5-UPDOWN",
     "time": "08:27:14",
     "date": "Feb  6",
-    "message": ": Line protocol on Interface Ethernet28 (added description in EOS 4.19.6M), changed state to up"
+    "message": "Line protocol on Interface Ethernet28 (added description in EOS 4.19.6M), changed state to up"
   },
   "facility": 20,
   "ip": "127.0.0.1",

--- a/tests/config/eos/INTERFACE_UP/default/yang.json
+++ b/tests/config/eos/INTERFACE_UP/default/yang.json
@@ -19,7 +19,7 @@
     "tag": "LINEPROTO-5-UPDOWN",
     "time": "08:27:14",
     "date": "Feb  6",
-    "message": ": Line protocol on Interface Ethernet28, changed state to up"
+    "message": "Line protocol on Interface Ethernet28, changed state to up"
   },
   "facility": 20,
   "ip": "127.0.0.1",

--- a/tests/config/eos/ISIS_NEIGHBOR_DOWN/default/yang.json
+++ b/tests/config/eos/ISIS_NEIGHBOR_DOWN/default/yang.json
@@ -45,7 +45,7 @@
         "tag": "ISIS-4-ISIS_ADJCHG",
         "time": "12:07:43",
         "date": "Dec 14",
-        "message": ": L1 Neighbor State Change for SystemID 1920.0000.2006 on et7 to DOWN: interface went down or no IP address on interface"
+        "message": "L1 Neighbor State Change for SystemID 1920.0000.2006 on et7 to DOWN: interface went down or no IP address on interface"
       },
       "facility": 3,
       "ip": "127.0.0.1",

--- a/tests/config/eos/ISIS_NEIGHBOR_UP/default/yang.json
+++ b/tests/config/eos/ISIS_NEIGHBOR_UP/default/yang.json
@@ -44,7 +44,7 @@
         "tag": "ISIS-4-ISIS_ADJCHG",
         "time": "12:08:12",
         "date": "Dec 14",
-        "message": ": L1 Neighbor State Change for SystemID 1920.0000.2006 on et7 to UP"
+        "message": "L1 Neighbor State Change for SystemID 1920.0000.2006 on et7 to UP"
       },
       "facility": 3,
       "ip": "127.0.0.1",

--- a/tests/config/eos/MAINTENANCE_MODE_ENDED/default/yang.json
+++ b/tests/config/eos/MAINTENANCE_MODE_ENDED/default/yang.json
@@ -17,7 +17,7 @@
     "processName": "MaintenanceMode",
     "tag": "MMODE-5-MAINT_UNIT_STATE_CHANGE",
     "pri": "100",
-    "message": ": Maintenance unit state changed for unit MAINT-UNIT. Old State maintenanceModeExit, New State active",
+    "message": "Maintenance unit state changed for unit MAINT-UNIT. Old State maintenanceModeExit, New State active",
     "facility": 12,
     "severity": 4
   },

--- a/tests/config/eos/MAINTENANCE_MODE_STARTED/default/yang.json
+++ b/tests/config/eos/MAINTENANCE_MODE_STARTED/default/yang.json
@@ -17,7 +17,7 @@
     "processName": "MaintenanceMode",
     "tag": "MMODE-5-MAINT_UNIT_STATE_CHANGE",
     "pri": "100",
-    "message": ": Maintenance unit state changed for unit MAINT-UNIT. Old State maintenanceModeEnter, New State underMaintenance",
+    "message": "Maintenance unit state changed for unit MAINT-UNIT. Old State maintenanceModeEnter, New State underMaintenance",
     "facility": 12,
     "severity": 4
   },

--- a/tests/config/eos/PROCESS_RESTART/default/yang.json
+++ b/tests/config/eos/PROCESS_RESTART/default/yang.json
@@ -19,7 +19,7 @@
   "tag": "PROCMGR-6-PROCESS_RESTART",
   "time": "02:50:31",
   "date": "Jan 24",
-  "message": ": Restarting 'Bgp' immediately (it had PID=32058)"
+  "message": "Restarting 'Bgp' immediately (it had PID=32058)"
 },
 "facility": 20,
 "ip": "127.0.0.1",

--- a/tests/config/eos/PROCESS_STARTED/default/yang.json
+++ b/tests/config/eos/PROCESS_STARTED/default/yang.json
@@ -20,7 +20,7 @@
   "tag": "PROCMGR-6-PROCESS_STARTED",
   "time": "02:50:31",
   "date": "Jan 24",
-  "message": ": 'Bgp' starting with PID=6186 (PPID=2030) -- execing '/usr/bin/Bgp'"
+  "message": "'Bgp' starting with PID=6186 (PPID=2030) -- execing '/usr/bin/Bgp'"
 },
 "facility": 20,
 "ip": "127.0.0.1",

--- a/tests/config/eos/PROCESS_TERMINATED/default/yang.json
+++ b/tests/config/eos/PROCESS_TERMINATED/default/yang.json
@@ -19,7 +19,7 @@
   "tag": "PROCMGR-6-PROCESS_TERMINATED",
   "time": "02:50:31",
   "date": "Jan 24",
-  "message": ": 'Tmp75-system' (PID=6170, status=9) has terminated."
+  "message": "'Tmp75-system' (PID=6170, status=9) has terminated."
 },
 "facility": 20,
 "ip": "127.0.0.1",

--- a/tests/config/eos/USER_ENTER_CONFIG_MODE/default/yang.json
+++ b/tests/config/eos/USER_ENTER_CONFIG_MODE/default/yang.json
@@ -19,7 +19,7 @@
 		"tag": "SYS-5-CONFIG_E",
 		"time": "12:20:55",
 		"date": "Oct 23",
-		"message": ": Enter configuration mode from console by admin on vty3 (127.0.0.1)",
+		"message": "Enter configuration mode from console by admin on vty3 (127.0.0.1)",
 		"severity": 5
 	},
 	"timestamp": 1540297255,

--- a/tests/config/eos/USER_EXIT_CONFIG_MODE/default/yang.json
+++ b/tests/config/eos/USER_EXIT_CONFIG_MODE/default/yang.json
@@ -19,7 +19,7 @@
 		"tag": "SYS-5-CONFIG_I",
 		"time": "12:23:41",
 		"date": "Oct 23",
-		"message": ": Configured from console by admin on vty3 (127.0.0.1)",
+		"message": "Configured from console by admin on vty3 (127.0.0.1)",
 		"severity": 5
 	},
 	"timestamp": 1540297421,

--- a/tests/config/eos/USER_WRITE_CONFIG/default/yang.json
+++ b/tests/config/eos/USER_WRITE_CONFIG/default/yang.json
@@ -19,7 +19,7 @@
 		"tag": "SYS-5-CONFIG_STARTUP",
 		"time": "12:22:50",
 		"date": "Oct 23",
-		"message": ": Startup config saved from system:/running-config by admin on vty3 (127.0.0.1).",
+		"message": "Startup config saved from system:/running-config by admin on vty3 (127.0.0.1).",
 		"severity": 5
 	},
 	"timestamp": 1540297370,


### PR DESCRIPTION
Correct how EOS logs are matched so that the extra colon and space are dropped from the message.