### PR TITLE
Add Infinera vendor support

### DIFF
--- a/napalm_logs/config/infinera/USER_LOGIN.yml
+++ b/napalm_logs/config/infinera/USER_LOGIN.yml
@@ -1,0 +1,15 @@
+# Infinera SECURITY messages for user login events
+messages:
+  - error: USER_LOGIN
+    tag: SECURITY
+    values:
+      timestamp: (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?)
+      sessionId: ([^;]+)
+      sessionType: (\w+)
+      user: ([^;]+)
+    line: '"time-stamp":{timestamp};"session-id":{sessionId};"session-type":{sessionType};"user-name":{user};"event/action":logged in'
+    model: openconfig-system
+    mapping:
+      variables:
+        system//aaa//authentication//users//user//{user}//state//username: user
+      static: {}

--- a/napalm_logs/config/infinera/init.yml
+++ b/napalm_logs/config/infinera/init.yml
@@ -1,0 +1,21 @@
+# Infinera syslog format (RFC5424 style via netsyslog relay)
+# Supported message types per vendor documentation:
+#   - ALARM: alarm notifications with severity, duration, service-affect
+#   - EVENT: system events with entity and attributes
+#   - CONFIGURATION: config changes with user, result, attributes
+#   - SECURITY: authentication events (login/logout)
+#
+# Example log:
+# Jan 20 05:01:59.657539 73dm8 netsyslog: <85>1 2026-01-20T05:02:17+00:00 dci01.abc01@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":...
+#
+prefixes:
+  - time_format: "%Y-%m-%dT%H:%M:%S"
+    values:
+      date: (\d{4}-\d{2}-\d{2})
+      time: (\d{2}:\d{2}:\d{2})
+      timezone: ([\+\-]\d{2}:\d{2})
+      host: '([\w\.\-]+)@::'
+      tag: (ALARM|EVENT|CONFIGURATION|SECURITY)
+      messageId: (\d+)
+      structuredData: (\[.*?\])
+    line: '1 {date}T{time}{timezone} {host} {tag} {messageId} {structuredData} '

--- a/tests/config/infinera/USER_LOGIN/default/syslog.msg
+++ b/tests/config/infinera/USER_LOGIN/default/syslog.msg
@@ -1,0 +1,1 @@
+<85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":sess-12345;"session-type":CLI;"user-name":admin;"event/action":logged in

--- a/tests/config/infinera/USER_LOGIN/default/yang.json
+++ b/tests/config/infinera/USER_LOGIN/default/yang.json
@@ -1,0 +1,40 @@
+{
+  "yang_message": {
+    "system": {
+      "aaa": {
+        "authentication": {
+          "users": {
+            "user": {
+              "admin": {
+                "state": {
+                  "username": "admin"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "message_details": {
+    "severity": 5,
+    "facility": 10,
+    "pri": "85",
+    "host": "dci01.waw02",
+    "tag": "SECURITY",
+    "date": "2026-01-20",
+    "time": "05:02:17",
+    "timezone": "+00:00",
+    "messageId": "401",
+    "structuredData": "[meta sequenceId=\"735\"]",
+    "message": "\"time-stamp\":2026-01-20T05:02:17Z;\"session-id\":sess-12345;\"session-type\":CLI;\"user-name\":admin;\"event/action\":logged in"
+  },
+  "timestamp": 1768978937,
+  "facility": 10,
+  "ip": "127.0.0.1",
+  "host": "dci01.waw02",
+  "yang_model": "openconfig-system",
+  "error": "USER_LOGIN",
+  "os": "infinera",
+  "severity": 5
+}


### PR DESCRIPTION
### Summary
Adds support for parsing syslog messages from Coriant / Infinera
### Changes
- Added [napalm_logs/config/infinera/init.yml](cci:7://file:///Users/fakrul/Downloads/Temp/napalm-logs/napalm_logs/config/infinera/init.yml:0:0-0:0) - prefix pattern for Infinera RFC5424-style syslog messages
- Added [napalm_logs/config/infinera/USER_LOGIN.yml](cci:7://file:///Users/fakrul/Downloads/Temp/napalm-logs/napalm_logs/config/infinera/USER_LOGIN.yml:0:0-0:0) - message definitions for SECURITY events (login/logout)

### Infinera Log Format
Infinera devices emit RFC5424-style syslog messages with the following structure:

Example:
`<85>1 2026-01-20T05:02:17+00:00 dci01.abc01@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":1234;"session-type":cli;"user-name":admin;"event/action":logged in`


### Supported Message Types
Per Infinera vendor documentation:
- **ALARM** - alarm notifications with severity, duration, service-affect
- **EVENT** - system events with entity and attributes  
- **CONFIGURATION** - config changes with user, result, attributes
- **SECURITY** - authentication events (login/logout) - implemented

### OpenConfig Mapping
USER_LOGIN and USER_LOGOUT events are mapped to:
- `openconfig-system` model
- Path: `system/aaa/authentication/users/user/{user}/state/username`

### Testing
Tested locally with sample Infinera syslog messages. Hostname extraction correctly captures device name (e.g., `dci01.abc01` from `dci01.abc01@::`).

**Local Test**
Raw Log: <85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in
Validation:
```
2026-02-10 22:40:24,926,926 [napalm_logs.listener.udp][DEBUG   ] [b'<85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in\n'] Received from udp ('127.0.0.1', 48122) from 1770723624.926784
2026-02-10 22:40:24,926,926 [napalm_logs.listener_proc][DEBUG   ] Received b'<85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in\n' from 127.0.0.1. Queueing to the server.
2026-02-10 22:40:24,927,927 [napalm_logs.server][DEBUG   ] [127.0.0.1] Dequeued message from <85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in
: 1770723624.927943
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching under ios
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+):\s+([^ ]+):\s+\*?(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\.(\d\d\d)\s?(\w+)?:\s+%([\w-]+):\s+Process\s+(\d+),\s+(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+):\s+([^ ]+):\s+\*?(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\.(\d+)\s?(\w+)?:\s+%([\w-]+):\s+(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] No match found for ios
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching under infinera
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>1\s+(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})([\+\-]\d{2}:\d{2})\s+([\w\.\-]+)@::\s+(ALARM|EVENT|CONFIGURATION|SECURITY)\s+(\d+)\s+(\[.*?\])\s+(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Adding infinera to list of matched OS
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching under opengear
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>([^ ]+)\s+(\w+)\s+(\d+-\w+-[\s|\d]\d)\s+(\d\d:\d\d:\d\d)\s+(\w+):\s+(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>([^ ]+)\s+(\w+)\s+(\d+-\w+-[\s|\d]\d)\s+(\d\d:\d\d:\d\d\.\d+)\s+(\w+):\s+(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] No match found for opengear
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching under fortinet
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] \<(\d+)\>date=(\d+-\d+-\d+)\s+time=(\d\d:\d\d:\d\d)\s+devname=(.*)\s+devid=(.*)\s+logid=(\d+)\s+type=(\w+)\s+subtype=(\w+)(.*)
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] No match found for fortinet
2026-02-10 22:40:24,928,928 [napalm_logs.server][DEBUG   ] Matching under junos
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+ +\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+(jlaunchd):\s+(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+/?(\w+)\[?(\d+)?\]?:\s+([\w\s]+):(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+(\w+)\[(\d+)\]:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+fpc(\d+)\s+(\w+)(?:(?:\[|\()(.+)(?:\]|\)))?:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+fpc(\d+)\s+fpc(\d+)\s+dcpfe:\s+(\w+)(?:(?:\[|\()(.+)(?:\]|\)))?:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+\s+\d+)\s+(\d\d:\d\d:\d\d)\s+(re\d.)?([^ ]+)\s+(fpc\d)(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+(jlaunchd):\s+(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+/?(\w+)\[?(\d+)?\]?:\s+([\w\s]+):(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+(\w+)\[(\d+)\]:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+fpc(\d+)\s+(\w+)(?:(?:\[|\()(.+)(?:\]|\)))?:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+fpc(\d+)\s+fpc(\d+)\s+dcpfe:\s+(\w+)(?:(?:\[|\()(.+)(?:\]|\)))?:(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+(re\d.)?([^ ]+)\s+(fpc\d)(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] No match found for junos
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching under sonic
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+)\s+(\d+-\d+-\d+)T(\d+:\d+:\d+)\.(\d{6})((?:\+|\-)\d{2}:\d{2})\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+([^ ]+)\s+(.*)
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] No match found for sonic
2026-02-10 22:40:24,929,929 [napalm_logs.server][DEBUG   ] Matching under huawei
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+-\d+-\d+)\s+(\d+:\d+:\d+)\.(\d{3})\.1\s+([^ ]+)\s+%%(\w+\/\w+\/\w+)(\(\w+\))\[(\d+)\]:(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] No match found for huawei
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching under eos
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+ +\d+)\s+(\d\d:\d\d:\d\d)\s+([^ ]+)\s+([\w-]+):\s+%([\w-]+)(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}[\.\d{3}]?[\+|-]\d{2}:\d{2})\s+([^ ]+)\s+([\w-]+):\s+%([\w-]+)(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] No match found for eos
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching under iosxr
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+):\s+([^ ]+)\s+([^ ]+):(\w+ +\d+)\s+(\d\d:\d\d:\d\d)(\.\d\d\d)\s?(\w\w\w)?:\s+(\w+)\[(\d+)\]:\s+%([\w-]+)\s+:\s+(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\d+):\s+([^ ]+):(\w+ +\d+)\s+(\d\d:\d\d:\d\d)(\.\d\d\d)\s?(\w\w\w)?:\s+(\w+)\[(\d+)\]:\s+%([\w-]+)\s+:\s+(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] No match found for iosxr
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching under netiron
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching using YAML-defined profiler:
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] \<(\d+)\>(\w+ +\d+)\s+(\d\d:\d\d:\d\d)\s+([^ ]+)\s+(\w+):\s+(.*)
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] No match found for netiron
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Matching under nxos
2026-02-10 22:40:24,930,930 [napalm_logs.server][DEBUG   ] Trying to match using the /home/fakrul/napalm-logs/napalm_logs/config/nxos/__init__.py custom python profiler
2026-02-10 22:40:24,930,930 [napalm_logs.utils][DEBUG   ] Matching regex "\<(\d+)\>([^ ]+): (\d+ \w+ +\d+) (\d\d:\d\d:\d\d) (\w\w\w): %([\w\d-]+): (.*)" on "<85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in
"
2026-02-10 22:40:24,931,931 [napalm_logs.utils][INFO    ] The regex didnt match
2026-02-10 22:40:24,931,931 [napalm_logs.utils][DEBUG   ] Matching regex "\<(\d+)\>(\d+ \w+ +\d+) (\d\d:\d\d:\d\d) ([^ ]+) %([\w\d-]+): (.*)" on "<85>1 2026-01-20T05:02:17+00:00 dci01.waw02@:: SECURITY 401 [meta sequenceId="735"] "time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in
"
2026-02-10 22:40:24,931,931 [napalm_logs.utils][INFO    ] The regex didnt match
2026-02-10 22:40:24,931,931 [napalm_logs.server][DEBUG   ] Match not found
2026-02-10 22:40:24,931,931 [napalm_logs.server][DEBUG   ] No match found for nxos
2026-02-10 22:40:24,931,931 [napalm_logs.server][DEBUG   ] Identified OS: infinera
2026-02-10 22:40:24,931,931 [napalm_logs.server][DEBUG   ] Queueing message to infinera
2026-02-10 22:40:24,932,932 [napalm_logs.device][DEBUG   ] infinera: dequeued {'date': '2026-01-20', 'time': '05:02:17', 'timezone': '+00:00', 'host': 'dci01.waw02', 'tag': 'SECURITY', 'messageId': '401', 'structuredData': '[meta sequenceId="735"]', 'pri': '85', 'message': '"time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in', '__prefix_id__': 0, 'facility': 10, 'severity': 5}, received from 127.0.0.1
2026-02-10 22:40:24,966,966 [tzlocal          ][DEBUG   ] /etc/timezone found, contents:
 Australia/Sydney

2026-02-10 22:40:24,966,966 [tzlocal          ][DEBUG   ] /etc/localtime found
2026-02-10 22:40:24,967,967 [tzlocal          ][DEBUG   ] 2 found:
 {'/etc/timezone': 'Australia/Sydney', '/etc/localtime is a symlink to': 'Australia/Sydney'}
2026-02-10 22:40:24,969,969 [napalm_logs.device][DEBUG   ] Generated OC object:
2026-02-10 22:40:24,969,969 [napalm_logs.device][DEBUG   ] {'system': {'aaa': {'authentication': {'users': {'user': {'rancid': {'state': {'username': 'rancid'}}}}}}}}
2026-02-10 22:40:24,969,969 [napalm_logs.device][DEBUG   ] Queueing to be published:
2026-02-10 22:40:24,969,969 [napalm_logs.device][DEBUG   ] {'error': 'USER_LOGIN', 'host': 'dci01.waw02', 'ip': '127.0.0.1', 'timestamp': 1768885337, 'yang_message': {'system': {'aaa': {'authentication': {'users': {'user': {'rancid': {'state': {'username': 'rancid'}}}}}}}}, 'message_details': {'date': '2026-01-20', 'time': '05:02:17', 'timezone': '+00:00', 'host': 'dci01.waw02', 'tag': 'SECURITY', 'messageId': '401', 'structuredData': '[meta sequenceId="735"]', 'pri': '85', 'message': '"time-stamp":2026-01-20T05:02:17Z;"session-id":2400:cb00:36:1092::ac46:1c5:37926;"session-type":cli;"user-name":rancid;"event/action":logged in', 'facility': 10, 'severity': 5}, 'yang_model': 'openconfig-system', 'os': 'infinera', 'facility': 10, 'severity': 5}
2026-02-10 22:40:24,971,971 [napalm_logs.publisher][DEBUG   ] Publishing the OC object
```

### Future Work
Additional message definitions can be added for ALARM, EVENT, and CONFIGURATION message types as needed.