### PR TITLE
fix kafka decoding error blocking consumption

### DIFF
--- a/napalm_logs/listener/kafka.py
+++ b/napalm_logs/listener/kafka.py
@@ -71,14 +71,20 @@ class KafkaListener(ListenerBase):
             raise ListenerException(error)
         log_source = msg.key
         if isinstance(log_source, bytes):
-            log_source = log_source.decode()
+            try:
+                log_source = log_source.decode()
+            except UnicodeDecodeError:
+                log.error("Unable to decode log source: %s", msg.key)
+                return "", ""
         try:
             decoded = json.loads(msg.value.decode("utf-8"))
         except ValueError:
             log.error("Not in json format: %s", msg.value.decode("utf-8"))
             return "", ""
         log_message = decoded.get("message")
-        log.debug("[%s] Received from kafka %s from %s", log_message, log_source, time.time())
+        log.debug(
+            "[%s] Received from kafka %s from %s", log_message, log_source, time.time()
+        )
         return log_message, log_source
 
     def stop(self):


### PR DESCRIPTION
For some reason we received a non utf-8 message from Kafka topic, and the application is getting stuck with this error:

```
Process Process-27:
Traceback (most recent call last):
  File "/usr/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3/dist-packages/napalm_logs/listener_proc.py", line 102, in start
    log_message, log_source = self.listener.receive()
                              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/napalm_logs/listener/kafka.py", line 83, in receive
    log_source = log_source.decode()
                 ^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa2 in position 1: invalid start byte
```

This fix try catch on the initial key decoding and return and follow the same error handling pattern as the message json decoding below.